### PR TITLE
fix: include /v1 suffix in all localhost URLs shown to users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ coverage/
 
 tmp/
 temp/
+.pi/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -714,7 +714,7 @@ clientsCmd
       }
 
       console.log(
-        `\n  Access Routstr at: http://localhost:${config.port || 8008}`,
+        `\n  Access Routstr at: http://localhost:${config.port || 8008}/v1`,
       );
       return;
     }
@@ -754,7 +754,7 @@ clientsCmd
       console.log(`  Name:   ${output.client.name}`);
       console.log(`  API Key: ${output.client.apiKey}`);
       console.log(
-        `\n  Access Routstr at: http://localhost:${config.port || 8008}`,
+        `\n  Access Routstr at: http://localhost:${config.port || 8008}/v1`,
       );
     }
   });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -203,7 +203,7 @@ async function main(): Promise<void> {
   });
 
   server.listen(port, async () => {
-    logger.log(`Routstr daemon listening on http://localhost:${port}`);
+    logger.log(`Routstr daemon listening on http://localhost:${port}/v1`);
 
     // Start the recurring model refresh job after initial bootstrap
     void ensureProvidersBootstrapped()

--- a/src/start-daemon.ts
+++ b/src/start-daemon.ts
@@ -26,7 +26,7 @@ export async function startDaemon(
     });
     clearTimeout(timeoutId);
     if (existing.ok) {
-      logger.log(`Routstr daemon already running on http://localhost:${port}`);
+      logger.log(`Routstr daemon already running on http://localhost:${port}/v1`);
       return;
     }
   } catch {


### PR DESCRIPTION
Updates all user-facing log messages to include the /v1 path suffix,
so clients know to use http://localhost:${port}/v1 when configuring
their API endpoints.

- src/cli.ts:717 — clients add --setup-all flow
- src/cli.ts:757 — clients add -n ${name} flow
- src/daemon/index.ts:206 — daemon startup message
- src/start-daemon.ts:29 — daemon already running message