### PR TITLE
fix: sync bootstrapped providers into store so providers list is complete

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   // Create shared ProviderManager for consistent failure tracking across all requests
   const providerManager = new ProviderManager(providerRegistry, store);
   const { ensureProvidersBootstrapped, getRoutstr21Models, getModelProviders } =
-    createModelService(modelManager);
+    createModelService(modelManager, store);
 
   const walletClient = createCocodClient({ cocodPath: config.cocodPath });
   const walletAdapter = await createWalletAdapter({

--- a/src/daemon/models.ts
+++ b/src/daemon/models.ts
@@ -1,4 +1,4 @@
-import { ModelManager } from "@routstr/sdk";
+import { ModelManager, type SdkStore } from "@routstr/sdk";
 import type { ExposedModel } from "./types";
 import { logger } from "../utils/logger";
 
@@ -16,7 +16,7 @@ export type ModelWithProviders = ExposedModel & {
   providers: ModelProviderInfo[];
 };
 
-export function createModelService(modelManager: ModelManager) {
+export function createModelService(modelManager: ModelManager, store: SdkStore) {
   let providerBootstrapPromise: Promise<void> | null = null;
 
   const ensureProvidersBootstrapped = (): Promise<void> => {
@@ -26,6 +26,22 @@ export function createModelService(modelManager: ModelManager) {
         const providers = await modelManager.bootstrapProviders(false);
         logger.log(`Bootstrapped ${providers.length} providers`);
         await modelManager.fetchModels(providers);
+
+        // Sync discovered providers into the store so `providers list` reflects
+        // the same set that the model manager knows about.
+        const { baseUrlsList, setBaseUrlsList } = store.getState();
+        const existing = new Set(baseUrlsList);
+        const merged = [
+          ...baseUrlsList,
+          ...providers.filter((url) => !existing.has(url)),
+        ];
+        if (merged.length !== baseUrlsList.length) {
+          setBaseUrlsList(merged);
+          logger.log(
+            `Synced ${merged.length - baseUrlsList.length} new provider(s) into store`,
+          );
+        }
+
         logger.log("Provider bootstrap complete.");
       })().catch((error) => {
         logger.error("Provider bootstrap failed:", error);


### PR DESCRIPTION
## Summary

- `routstrd providers list` and `routstrd models -m <id>` were showing different provider sets because they read from different sources
- `providers list` reads `store.baseUrlsList` (local state), while the models command uses the `ModelManager` cache populated by `bootstrapProviders`
- Providers discovered during bootstrap (e.g. `privateprovider.xyz`) were never written back into the store

## Fix

After `bootstrapProviders` resolves in `createModelService`, newly discovered URLs are merged into `store.baseUrlsList` (append-only, no duplicates, existing entries preserved). `createModelService` now receives `store` as a second argument.

## Test plan

- [x] Run `routstrd providers list` — should now include providers previously only visible via `routstrd models -m <id>`
- [x] Confirm no duplicate entries appear in the providers list
- [x] Confirm existing enabled/disabled state of known providers is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)