### PR TITLE
fix: surface cocod "Not enough proofs" as InsufficientBalanceError

### DIFF
--- a/src/daemon/wallet/index.ts
+++ b/src/daemon/wallet/index.ts
@@ -1,4 +1,5 @@
 import { getDecodedToken } from "@cashu/cashu-ts";
+import { InsufficientBalanceError } from "@routstr/sdk";
 import { logger } from "../../utils/logger";
 import { createCocodClient, type CocodClient } from "./cocod-client";
 
@@ -77,6 +78,10 @@ export async function createWalletAdapter(
             );
             await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
             continue;
+          }
+
+          if (errorMessage.includes("Not enough proofs")) {
+            throw new InsufficientBalanceError(amount, 0);
           }
 
           logger.error("Error in walletAdapter sendToken:", error);


### PR DESCRIPTION
## Summary
- Map cocod's `"Send failed: Not enough proofs to send"` error to `InsufficientBalanceError` in `walletAdapter.sendToken`
- Without this fix, the error propagated as a generic `Error`, causing the HTTP handler to return 500 instead of the structured 402 `insufficient_balance` response

## Context
When cocod cannot assemble enough proofs to send (e.g. due to denomination fragmentation or stale proof state), it returns `"Send failed: Not enough proofs to send"`. The SDK's pre-flight balance checks may pass even in this case, so the runtime failure from cocod is the only signal. The daemon HTTP handler already handles `InsufficientBalanceError` correctly (returns 402), but it was never reaching that path.

## Test plan
- [ ] Confirm that a cocod "Not enough proofs" error now returns HTTP 402 with `error_type: "insufficient_balance"` instead of 500
- [ ] Verify other cocod errors still propagate as before (generic 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)