### PR TITLE
feat: widen and reposition client column in TUI recent requests

### DIFF
--- a/src/tui/usage/render.ts
+++ b/src/tui/usage/render.ts
@@ -511,21 +511,21 @@ export function renderRecent(stats: UsageStats, width: number): string {
   const recentEntries = stats.entries.slice(0, 50);
   if (recentEntries.length === 0) return renderBox(["No recent entries"], width, "Recent Requests");
 
-  const clientCol = 10;
+  const clientCol = 14;
   const lines: string[] = [];
-  lines.push(`${COLORS.bold}${"TIME".padEnd(10)} ${"CLIENT".padEnd(clientCol)} ${"MODEL".padEnd(18)} ${"TOKENS".padEnd(10)} ${"COST".padEnd(12)} ${"PROVIDER".slice(0, Math.max(0, width - 70))}${COLORS.reset}`);
+  lines.push(`${COLORS.bold}${"TIME".padEnd(10)} ${"MODEL".padEnd(18)} ${"TOKENS".padEnd(10)} ${"COST".padEnd(12)} ${"PROVIDER".padEnd(16)} ${"CLIENT".slice(0, clientCol)}${COLORS.reset}`);
   lines.push(COLORS.dim + "─".repeat(width - 4) + COLORS.reset);
 
   for (const entry of recentEntries) {
     const time = formatTime(entry.timestamp).slice(0, 8);
-    const clientName = (entry.client || "unknown").slice(0, clientCol - 1).padEnd(clientCol);
-    const clientColor = CLIENT_COLORS[entry.client || "unknown"] || CLIENT_COLORS.default || COLORS.white;
     const model = entry.modelId.slice(0, 18).padEnd(18);
     const tokens = `${formatNumber(entry.totalTokens).padEnd(6)} (${formatNumber(entry.promptTokens)}+${formatNumber(entry.completionTokens)})`;
     const cost = `${formatCost(entry.satsCost).padEnd(8)} sats`;
-    const provider = (entry.baseUrl || "unknown").replace("https://", "").replace("http://", "").slice(0, Math.max(0, width - 70));
+    const provider = (entry.baseUrl || "unknown").replace("https://", "").replace("http://", "").slice(0, 16).padEnd(16);
+    const clientName = (entry.client || "unknown").slice(0, clientCol - 1);
+    const clientColor = CLIENT_COLORS[entry.client || "unknown"] || CLIENT_COLORS.default || COLORS.white;
     const modelColor = MODEL_COLORS[entry.modelId] || MODEL_COLORS.default;
-    lines.push(`${COLORS.dim}${time}${COLORS.reset} ${clientColor}${clientName}${COLORS.reset} ${modelColor}${model}${COLORS.reset} ${tokens.padEnd(10)} ${COLORS.green}${cost}${COLORS.reset} ${COLORS.dim}${provider}${COLORS.reset}`);
+    lines.push(`${COLORS.dim}${time}${COLORS.reset} ${modelColor}${model}${COLORS.reset} ${tokens.padEnd(10)} ${COLORS.green}${cost}${COLORS.reset} ${COLORS.dim}${provider}${COLORS.reset} ${clientColor}${clientName}${COLORS.reset}`);
   }
 
   return renderBox(lines, width, `Recent Requests (${stats.entries.length} shown)`);


### PR DESCRIPTION
## Summary
- Widens CLIENT column from 10 to 14 chars for better readability
- Moves CLIENT to the last column position: `TIME | MODEL | TOKENS | COST | PROVIDER | CLIENT`
- Gives PROVIDER a fixed 16-char width so CLIENT has consistent spacing

## Test plan
- [ ] Open TUI, navigate to Recent Requests tab
- [ ] Verify CLIENT is the last column
- [ ] Verify longer client names display properly (up to 13 chars)
- [ ] Verify table remains readable on 80+ width terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)