### PR TITLE
feat(tui): add Npubs tab grouping usage by ownerNpub

### DIFF
--- a/src/tui/usage/app.ts
+++ b/src/tui/usage/app.ts
@@ -1,5 +1,6 @@
-import { TABS } from "./constants.ts";
-import { fetchBalance, fetchStatus, fetchUsage, type BalanceInfo, type StatusInfo } from "./data.ts";
+import { getVisibleTabs } from "./constants.ts";
+import type { Tab } from "./types.ts";
+import { fetchBalance, fetchClients, fetchStatus, fetchUsage, hasAnyNpubs, isDaemonRunning, type BalanceInfo, type ClientInfo, type StatusInfo } from "./data.ts";
 import {
   applyScrollToContent,
   exitSearchMode,
@@ -28,7 +29,6 @@ import {
 import { COLORS } from "./constants.ts";
 import { renderHeader, renderSearchBar, renderSeparator, renderTabContent, renderTabs } from "./render.ts";
 import type { TabId, UsageStats } from "./types.ts";
-import { isDaemonRunning } from "../../utils/daemon-client.ts";
 
 export async function runUsageTui(): Promise<void> {
   const running = await isDaemonRunning();
@@ -46,6 +46,8 @@ export async function runUsageTui(): Promise<void> {
   let stats: UsageStats | null = null;
   let balance: BalanceInfo | null = null;
   let status: StatusInfo | null = null;
+  let clients: ClientInfo[] = [];
+  let visibleTabs: Tab[] = getVisibleTabs(false);
   let refreshInterval: ReturnType<typeof setInterval> | null = null;
   let shouldUpdate = true;
   let autoRefresh = true;
@@ -90,6 +92,14 @@ export async function runUsageTui(): Promise<void> {
         stats = await fetchUsage(10000);
         balance = await fetchBalance();
         status = await fetchStatus();
+        clients = await fetchClients();
+        const npubsVisible = hasAnyNpubs(clients);
+        visibleTabs = getVisibleTabs(npubsVisible);
+        // If current tab is npubs but it's no longer visible, fall back to clients
+        if (currentTab === "npubs" && !npubsVisible) {
+          currentTab = "clients";
+          vimState.scrollPos = 0;
+        }
         shouldUpdate = false;
       }
 
@@ -104,9 +114,9 @@ export async function runUsageTui(): Promise<void> {
         return;
       }
 
-      const content = renderTabContent(currentTab, stats, balance, status, width);
+      const content = renderTabContent(currentTab, stats, balance, status, width, clients);
       const footer = `${COLORS.dim}Press [Q] to quit, [R] to refresh, [A] to toggle auto-refresh${autoRefresh ? " (on)" : " (off)"}  scroll:${vimState.scrollPos}${COLORS.reset}${vimState.mode === "normal" ? `  ${COLORS.yellow}vim: hjkl/arrows, / search, g top, gg bottom${COLORS.reset}` : ""}`;
-      const chrome = renderHeader(currentTab, width) + renderTabs(currentTab) + renderSeparator(width) + renderSearchBar();
+      const chrome = renderHeader(currentTab, width, visibleTabs) + renderTabs(currentTab, visibleTabs) + renderSeparator(width) + renderSearchBar();
       const chromeLines = chrome.split("\n").length - 1;
       const footerSeparator = renderSeparator(width);
       const footerLines = footerSeparator.split("\n").length - 1;
@@ -176,15 +186,15 @@ export async function runUsageTui(): Promise<void> {
       return;
     }
     if (key === "l" || key === "\x1b[C" || key === "\x1bOC") {
-      const currentIdx = TABS.findIndex((t) => t.id === currentTab);
-      currentTab = TABS[(currentIdx + 1) % TABS.length]!.id;
+      const currentIdx = visibleTabs.findIndex((t) => t.id === currentTab);
+      currentTab = visibleTabs[(currentIdx + 1) % visibleTabs.length]!.id;
       vimState.scrollPos = 0;
       void render(false);
       return;
     }
     if (key === "h" || key === "\x1b[D" || key === "\x1bOD") {
-      const currentIdx = TABS.findIndex((t) => t.id === currentTab);
-      currentTab = TABS[(currentIdx - 1 + TABS.length) % TABS.length]!.id;
+      const currentIdx = visibleTabs.findIndex((t) => t.id === currentTab);
+      currentTab = visibleTabs[(currentIdx - 1 + visibleTabs.length) % visibleTabs.length]!.id;
       vimState.scrollPos = 0;
       void render(false);
       return;
@@ -226,7 +236,7 @@ export async function runUsageTui(): Promise<void> {
     }
     if (key === "\x1b") { scrollToTop(); void render(false); return; }
 
-    const tab = TABS.find((t) => t.key === key);
+    const tab = visibleTabs.find((t) => t.key === key);
     if (tab) {
       currentTab = tab.id;
       vimState.scrollPos = 0;

--- a/src/tui/usage/constants.ts
+++ b/src/tui/usage/constants.ts
@@ -1,14 +1,27 @@
 import type { Tab } from "./types.ts";
 
-export const TABS: Tab[] = [
+export const ALL_TABS: Tab[] = [
   { id: "overview", name: "Overview", key: "1" },
   { id: "today", name: "Today", key: "2" },
   { id: "models", name: "Models", key: "3" },
   { id: "providers", name: "Providers", key: "4" },
   { id: "tokens", name: "Tokens", key: "5" },
   { id: "clients", name: "Clients", key: "6" },
-  { id: "recent", name: "Recent", key: "7" },
+  { id: "npubs", name: "Npubs", key: "7" },
+  { id: "recent", name: "Recent", key: "8" },
 ];
+
+/**
+ * Returns the visible tab list, hiding the Npubs tab when no clients
+ * have an ownerNpub. Keys are re-assigned sequentially (1..N).
+ */
+export function getVisibleTabs(hasNpubs: boolean): Tab[] {
+  const tabs = ALL_TABS.filter((t) => t.id !== "npubs" || hasNpubs);
+  return tabs.map((t, i) => ({ ...t, key: String(i + 1) }));
+}
+
+/** Default tab list (no npub data yet). */
+export const TABS: Tab[] = getVisibleTabs(false);
 
 export const COLORS = {
   reset: "\x1b[0m",

--- a/src/tui/usage/data.ts
+++ b/src/tui/usage/data.ts
@@ -1,6 +1,8 @@
 import type { UsageTrackingEntry } from "../../daemon/types.ts";
 import { callDaemon, isDaemonRunning } from "../../utils/daemon-client.ts";
-import type { ClientStats, DayStats, ModelStats, ProviderStats, UsageStats } from "./types.ts";
+import type { ClientStats, DayStats, ModelStats, NpubStats, ProviderStats, UsageStats } from "./types.ts";
+
+export { isDaemonRunning };
 
 export interface BalanceKey {
   id: string;
@@ -222,6 +224,78 @@ export function getClientStats(entries: UsageTrackingEntry[]): ClientStats[] {
   }
   return Array.from(clients.values()).sort((a, b) => b.satsCost - a.satsCost);
 }
+
+// ─── Client / Npub helpers ────────────────────────────────────────────
+
+export interface ClientInfo {
+  clientId: string;
+  name: string;
+  ownerNpub?: string;
+}
+
+export async function fetchClients(): Promise<ClientInfo[]> {
+  try {
+    const running = await isDaemonRunning();
+    if (!running) return [];
+
+    const result = await callDaemon("/clients");
+    if (result.error) return [];
+
+    const output = result.output as {
+      clients?: Array<{ id: string; name: string; ownerNpub?: string }>;
+    };
+
+    return (output?.clients || []).map((c) => ({
+      clientId: c.id,
+      name: c.name,
+      ownerNpub: c.ownerNpub,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export function hasAnyNpubs(clients: ClientInfo[]): boolean {
+  return clients.some((c) => !!c.ownerNpub);
+}
+
+export function getNpubStats(entries: UsageTrackingEntry[], clients: ClientInfo[]): NpubStats[] {
+  // Build client-id → ownerNpub lookup
+  const clientNpubMap = new Map<string, string>();
+  for (const c of clients) {
+    if (c.ownerNpub) {
+      clientNpubMap.set(c.clientId, c.ownerNpub);
+    }
+  }
+
+  // Aggregate usage per npub
+  const npubs = new Map<string, NpubStats>();
+  for (const entry of entries) {
+    const npub = clientNpubMap.get(entry.client || "");
+    if (!npub) continue; // skip entries whose client has no ownerNpub
+
+    const existing = npubs.get(npub) || {
+      npub,
+      requests: 0,
+      satsCost: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    };
+    npubs.set(npub, {
+      ...existing,
+      requests: existing.requests + 1,
+      satsCost: existing.satsCost + entry.satsCost,
+      promptTokens: existing.promptTokens + entry.promptTokens,
+      completionTokens: existing.completionTokens + entry.completionTokens,
+      totalTokens: existing.totalTokens + entry.totalTokens,
+    });
+  }
+
+  return Array.from(npubs.values()).sort((a, b) => b.satsCost - a.satsCost);
+}
+
+// ─── Totals ───────────────────────────────────────────────────────────
 
 export function getTotals(entries: UsageTrackingEntry[] | undefined) {
   if (!entries || !Array.isArray(entries)) {

--- a/src/tui/usage/render.ts
+++ b/src/tui/usage/render.ts
@@ -1,4 +1,5 @@
-import { CLIENT_COLORS, COLORS, MODEL_COLORS, TABS } from "./constants.ts";
+import { CLIENT_COLORS, COLORS, MODEL_COLORS } from "./constants.ts";
+import type { Tab } from "./types.ts";
 import {
   formatDate,
   formatNumber,
@@ -7,9 +8,11 @@ import {
   getDayStats,
   getHourlyToday,
   getModelStats,
+  getNpubStats,
   getProviderStats,
   getTodayStart,
   getTotals,
+  type ClientInfo,
 } from "./data.ts";
 import { vimState } from "./state.ts";
 import { stripAnsi } from "./terminal.ts";
@@ -30,10 +33,11 @@ function formatReqs(value: number): string {
   return value.toString();
 }
 
-export function renderHeader(activeTab: TabId, width: number): string {
+export function renderHeader(activeTab: TabId, width: number, visibleTabs: Tab[]): string {
   const title = `${COLORS.bold}${COLORS.cyan}ROUTSTRD USAGE MONITOR${COLORS.reset}`;
   const vimIndicator = `${COLORS.yellow}[vim]${COLORS.reset}`;
-  const help = `${COLORS.dim}[Q] Quit  [↑↓] Scroll  [←→] Tabs  [1-7] Tabs  [R] Refresh${COLORS.reset}`;
+  const maxKey = visibleTabs.length;
+  const help = `${COLORS.dim}[Q] Quit  [↑↓] Scroll  [←→] Tabs  [1-${maxKey}] Tabs  [R] Refresh${COLORS.reset}`;
   const fill = width - title.length - help.length - vimIndicator.length - 6;
   return `${title}${vimIndicator}${" ".repeat(Math.max(1, fill))}${help}\n`;
 }
@@ -49,8 +53,8 @@ export function renderSearchBar(): string {
   return `\n${searchLine}${placeholder}\n`;
 }
 
-export function renderTabs(activeTab: TabId): string {
-  const tabStr = TABS.map((tab) => tab.id === activeTab
+export function renderTabs(activeTab: TabId, visibleTabs: Tab[]): string {
+  const tabStr = visibleTabs.map((tab) => tab.id === activeTab
     ? `${COLORS.bgBlue} ${tab.key}:${tab.name} ${COLORS.reset}`
     : `${COLORS.dim}[${tab.key}]${COLORS.reset} ${tab.name}`).join("  ");
   return `${" ".repeat(2)}${tabStr}\n`;
@@ -507,6 +511,99 @@ export function renderClients(stats: UsageStats, width: number): string {
   return output;
 }
 
+export function renderNpubs(stats: UsageStats, clients: ClientInfo[], width: number): string {
+  const npubStats = getNpubStats(stats.entries, clients);
+  if (npubStats.length === 0) return renderBox(["No npub data available"], width, "Npub Breakdown");
+
+  const totalCost = stats.totalSatsCost;
+  const maxCost = npubStats[0]!.satsCost;
+  const lines: string[] = [];
+
+  const col1 = 24; // Npub (truncated)
+  const col2 = 12; // Requests
+  const col3 = 24; // Cost
+  const col4 = 12; // Tokens
+
+  const hNpub = "Npub".padEnd(col1);
+  const hReqs = "Requests".padEnd(col2);
+  const hCost = "Cost".padEnd(col3);
+  const hTok = "Tokens".padEnd(col4);
+  lines.push(`${COLORS.bold}${hNpub}${hReqs}${hCost}${hTok}Avg Cost${COLORS.reset}`);
+  lines.push(COLORS.dim + "─".repeat(Math.max(0, width - 4)) + COLORS.reset);
+
+  startBarSection("npub-detail", col1);
+  for (const npub of npubStats) {
+    const pct = totalCost > 0 ? ((npub.satsCost / totalCost) * 100).toFixed(1) : "0.0";
+    const avgCostFormatted = formatCost(npub.requests > 0 ? npub.satsCost / npub.requests : 0);
+    const shortNpub = truncateNpub(npub.npub);
+
+    const dNpub = shortNpub.padEnd(col1);
+    const dReqs = formatReqs(npub.requests).padEnd(col2);
+    const dCost = `${formatCost(npub.satsCost)} sats (${pct}%)`.padEnd(col3);
+    const dTok = formatNumber(npub.totalTokens).padEnd(col4);
+    const dAvg = `${avgCostFormatted} sats/req`;
+
+    lines.push(
+      `${COLORS.magenta}${COLORS.bold}${dNpub}${COLORS.reset}` +
+      `${dReqs}` +
+      `${COLORS.green}${dCost}${COLORS.reset}` +
+      `${COLORS.dim}${dTok}${dAvg}${COLORS.reset}`
+    );
+    // Full npub on its own line for copy-ability
+    lines.push(`  ${COLORS.dim}${npub.npub}${COLORS.reset}`);
+    lines.push(`  ${renderBarChart("", npub.satsCost, maxCost, width - 6, COLORS.magenta, Number(pct), "npub-detail")}`);
+    lines.push("");
+  }
+  endBarSection("npub-detail");
+
+  let output = renderBox(lines, width, "Npub Breakdown");
+
+  // Top models per npub (same pattern as clients tab)
+  const npubModelMap = new Map<string, Map<string, { requests: number; satsCost: number; tokens: number }>>();
+  const clientNpubMap = new Map<string, string>();
+  for (const c of clients) {
+    if (c.ownerNpub) clientNpubMap.set(c.clientId, c.ownerNpub);
+  }
+
+  for (const entry of stats.entries) {
+    const npub = clientNpubMap.get(entry.client || "");
+    if (!npub) continue;
+    const model = entry.modelId;
+    if (!npubModelMap.has(npub)) npubModelMap.set(npub, new Map());
+    const modelMap = npubModelMap.get(npub)!;
+    const existing = modelMap.get(model) || { requests: 0, satsCost: 0, tokens: 0 };
+    modelMap.set(model, {
+      requests: existing.requests + 1,
+      satsCost: existing.satsCost + entry.satsCost,
+      tokens: existing.tokens + entry.totalTokens,
+    });
+  }
+
+  const npubModelLines: string[] = [];
+  for (const topNpub of npubStats.slice(0, 5)) {
+    const modelMap = npubModelMap.get(topNpub.npub);
+    if (!modelMap) continue;
+    const models = Array.from(modelMap.entries()).sort((a, b) => b[1].satsCost - a[1].satsCost).slice(0, 5);
+    npubModelLines.push(`${COLORS.bold}${truncateNpub(topNpub.npub)}${COLORS.reset} (${formatReqs(topNpub.requests)} reqs, ${formatCost(topNpub.satsCost)} sats)`);
+    for (const [model, data] of models) {
+      npubModelLines.push(`  ${(MODEL_COLORS[model] || MODEL_COLORS.default)}${model.padEnd(18)}${COLORS.reset} ${formatNumber(data.tokens).padEnd(8)} tokens  ${formatCost(data.satsCost)} sats`);
+    }
+    npubModelLines.push("");
+  }
+
+  if (npubModelLines.length > 0) {
+    output += "\n" + renderBox(npubModelLines, width, "Top Models per Npub");
+  }
+
+  return output;
+}
+
+/** Truncate an npub for display: first 10 chars + … + last 6 chars. */
+function truncateNpub(npub: string): string {
+  if (npub.length <= 24) return npub;
+  return npub.slice(0, 10) + "…" + npub.slice(-6);
+}
+
 export function renderRecent(stats: UsageStats, width: number): string {
   const recentEntries = stats.entries.slice(0, 50);
   if (recentEntries.length === 0) return renderBox(["No recent entries"], width, "Recent Requests");
@@ -528,7 +625,7 @@ export function renderRecent(stats: UsageStats, width: number): string {
   return renderBox(lines, width, `Recent Requests (${stats.entries.length} shown)`);
 }
 
-export function renderTabContent(activeTab: TabId, stats: UsageStats, balance: BalanceInfo | null, status: StatusInfo | null, width: number): string {
+export function renderTabContent(activeTab: TabId, stats: UsageStats, balance: BalanceInfo | null, status: StatusInfo | null, width: number, clients: ClientInfo[] = []): string {
   switch (activeTab) {
     case "overview": return renderOverview(stats, balance, status, width);
     case "today": return renderToday(stats, width);
@@ -536,6 +633,7 @@ export function renderTabContent(activeTab: TabId, stats: UsageStats, balance: B
     case "providers": return renderProviders(stats, width);
     case "tokens": return renderTokens(stats, width);
     case "clients": return renderClients(stats, width);
+    case "npubs": return renderNpubs(stats, clients, width);
     case "recent": return renderRecent(stats, width);
     default: return "Unknown tab";
   }

--- a/src/tui/usage/types.ts
+++ b/src/tui/usage/types.ts
@@ -44,12 +44,21 @@ export interface ClientStats {
   totalTokens: number;
 }
 
-export type TabId = "overview" | "today" | "models" | "providers" | "tokens" | "clients" | "recent";
+export type TabId = "overview" | "today" | "models" | "providers" | "tokens" | "clients" | "npubs" | "recent";
 
 export interface Tab {
   id: TabId;
   name: string;
   key: string;
+}
+
+export interface NpubStats {
+  npub: string;
+  requests: number;
+  satsCost: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
 }
 
 export interface VimState {


### PR DESCRIPTION
## Summary

Adds a new **Npubs** tab to the TUI that groups usage data by `ownerNpub` instead of by client ID.

### What changed

- **New tab**: "Npubs" sits between Clients (6) and Recent (8, renumbered from 7)
- **Conditional visibility**: The Npubs tab is completely hidden when no clients have an `ownerNpub` — tab keys dynamically renumber 1-7 (without npubs) or 1-8 (with npubs)
- **Usage grouping**: Maps each usage entry's `client` field → client entry's `ownerNpub` via the `/clients` endpoint, then aggregates requests/cost/tokens per npub
- **Display**: Truncated npub (`npub1jgcj9…clvw2`) in the table row, full npub on a detail line for copy-ability, bar charts with cost percentages
- **Sub-section**: "Top Models per Npub" (top 5 npubs, top 5 models each) mirroring the Clients tab pattern
- **Graceful fallback**: If currently on the Npubs tab and npubs become unavailable on refresh, falls back to the Clients tab

### Files changed

| File | Change |
|------|--------|
| `src/tui/usage/types.ts` | Added `NpubStats` interface, `"npubs"` to `TabId` union |
| `src/tui/usage/constants.ts` | `ALL_TABS` with 8 tabs, `getVisibleTabs(hasNpubs)` for dynamic visibility |
| `src/tui/usage/data.ts` | `fetchClients()`, `hasAnyNpubs()`, `getNpubStats()` |
| `src/tui/usage/render.ts` | `renderNpubs()`, `truncateNpub()`, updated signatures for dynamic tab lists |
| `src/tui/usage/app.ts` | Fetches clients, computes `visibleTabs`, passes through render pipeline |

### Screenshots

N/A — TUI text interface. Run `routstrd` and press `7` to see the Npubs tab (when npub-bearing clients exist).