### PR TITLE
feat: add context window support to pi integration

### DIFF
--- a/src/integrations/pi.ts
+++ b/src/integrations/pi.ts
@@ -8,6 +8,7 @@ import { callDaemon, getDaemonBaseUrl } from "../utils/daemon-client";
 
 type PiModelEntry = {
   id: string;
+  contextWindow?: number;
 };
 
 type PiProviderConfig = {
@@ -60,9 +61,13 @@ export async function installPiIntegration(
       return;
     }
 
-    const providerModels: PiModelEntry[] = models.map((model) => ({
-      id: model.id,
-    }));
+    const providerModels: PiModelEntry[] = models.map((model) => {
+      const entry: PiModelEntry = { id: model.id };
+      if (model.context_length !== undefined && model.context_length > 0) {
+        entry.contextWindow = model.context_length;
+      }
+      return entry;
+    });
 
     piConfig.providers["routstr"] = {
       baseUrl,

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -15,6 +15,7 @@ export interface IntegrationConfig {
 export type RoutstrModel = {
   id: string;
   name?: string;
+  context_length?: number;
 };
 
 export type IntegrationFn = (


### PR DESCRIPTION
## Summary

Adds context window (`contextWindow`) support to the Pi agent integration. When models expose a `context_length` field, it is now propagated into the Pi models.json configuration.

## Changes

- **`src/integrations/registry.ts`** — Added optional `context_length` field to `RoutstrModel` type
- **`src/integrations/pi.ts`** — 
  - Added optional `contextWindow` to `PiModelEntry` type
  - Maps `model.context_length` to `entry.contextWindow` when defined and greater than 0

## Motivation

Pi agent supports a `contextWindow` field per model entry (see [pi docs on models](https://github.com/earendil-works/pi?tab=readme-ov-file#models)). By passing this through, Pi can better understand model capabilities and select appropriate models for different tasks.