### PR TITLE
feat(wallet): replace cocod with coco-core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,15 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "routstrd",
       "dependencies": {
         "@cashu/cashu-ts": "^4.3.0",
-        "@routstr/sdk": "file:../routstr-sdk",
+        "@cashu/coco-core": "^1.0.1",
+        "@cashu/coco-sqlite-bun": "^1.0.1",
+        "@routstr/sdk": "^0.3.9",
+        "@scure/bip39": "^2.2.0",
         "applesauce-core": "^5.1.0",
         "applesauce-relay": "^5.1.0",
         "applesauce-wallet-connect": "^6.0.0",
@@ -27,71 +31,15 @@
   "packages": {
     "@cashu/cashu-ts": ["@cashu/cashu-ts@4.5.1", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-AGB7wh1SC0iANRSsdwM091eoS1uVhSf/Qf2VM3plw8EzlYjiFkwSa9X0Nh6NpsE1VVeAuPpNInvpznvElp2Q0A=="],
 
-    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+    "@cashu/coco-core": ["@cashu/coco-core@1.0.1", "", { "dependencies": { "@cashu/cashu-ts": "^3.5.0", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/bip32": "^2.0.1" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Nv0T9+K49X+jqnrqn65Vgn/4Id+271JyHTgjwP/URdgShIJX3O8aGH4uidNphKnuBEa0EZKWPiFRn5K4mXh9jA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+    "@cashu/coco-sqlite-bun": ["@cashu/coco-sqlite-bun@1.0.1", "", { "peerDependencies": { "@cashu/coco-core": "1.0.1", "typescript": "^5" } }, "sha512-u6lnC3c8+qopD1CuLkcScbxcU1O+STrTz9+fwN09filD4PS+vYPCQNgygIfzKWnCaF8gXFRUuJsXSMqHDImJTw=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+    "@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
-
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
-
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
-
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
-
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
-
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
-
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
-
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
-
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
-
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
-
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
-
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
-
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
-
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
-
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
-
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
-
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
-
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
-
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
-
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
-
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
-
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
-
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
-
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
-
-    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
-
-    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
-
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@libsql/client": ["@libsql/client@0.15.15", "", { "dependencies": { "@libsql/core": "^0.15.14", "@libsql/hrana-client": "^0.7.0", "js-base64": "^3.7.5", "libsql": "^0.5.22", "promise-limit": "^2.7.0" } }, "sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w=="],
 
@@ -131,63 +79,13 @@
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.61.1", "", { "os": "android", "cpu": "arm" }, "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA=="],
-
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.61.1", "", { "os": "android", "cpu": "arm64" }, "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw=="],
-
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.61.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA=="],
-
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.61.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ=="],
-
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.61.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw=="],
-
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.61.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw=="],
-
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.61.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA=="],
-
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.61.1", "", { "os": "linux", "cpu": "arm" }, "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ=="],
-
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.61.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg=="],
-
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.61.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w=="],
-
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ=="],
-
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.61.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.61.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw=="],
-
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g=="],
-
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.61.1", "", { "os": "linux", "cpu": "none" }, "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ=="],
-
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.61.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g=="],
-
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.61.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q=="],
-
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.61.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw=="],
-
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.61.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.61.1", "", { "os": "none", "cpu": "arm64" }, "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA=="],
-
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.61.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g=="],
-
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.61.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.61.1", "", { "os": "win32", "cpu": "x64" }, "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ=="],
-
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.61.1", "", { "os": "win32", "cpu": "x64" }, "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw=="],
-
-    "@routstr/sdk": ["@routstr/sdk@file:../routstr-sdk", { "dependencies": { "@cashu/cashu-ts": "^3.1.1", "applesauce-core": "^5.1.0", "applesauce-relay": "^5.1.0", "applesauce-sqlite": "^6.0.0", "rxjs": "^7.8.1", "zustand": "^5.0.5" }, "devDependencies": { "@types/better-sqlite3": "^7.6.12", "@types/node": "^22.0.0", "joycon": "^3.1.1", "tsup": "^8.5.1", "typescript": "^5.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.10.0" }, "peerDependencies": { "typescript": ">=5.0.0" } }],
+    "@routstr/sdk": ["@routstr/sdk@0.3.10", "", { "dependencies": { "@cashu/cashu-ts": "^3.1.1", "applesauce-core": "^5.1.0", "applesauce-relay": "^5.1.0", "applesauce-sqlite": "^6.0.0", "rxjs": "^7.8.1", "zustand": "^5.0.5" }, "optionalDependencies": { "better-sqlite3": "^12.10.0" }, "peerDependencies": { "typescript": ">=5.0.0" } }, "sha512-DaRDO+jxEEd0xRj4BSHZBvVNeaKFANgLQ0iOZMkR6860lLWA0kqOb6uONfDFMpT2x+g+EOeeNsqbeEZuKUYM+Q=="],
 
     "@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
     "@scure/bip32": ["@scure/bip32@2.2.0", "", { "dependencies": { "@noble/curves": "2.2.0", "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg=="],
 
-    "@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
+    "@scure/bip39": ["@scure/bip39@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A=="],
 
     "@tursodatabase/database": ["@tursodatabase/database@0.2.2", "", { "dependencies": { "@tursodatabase/database-common": "^0.2.2" }, "optionalDependencies": { "@tursodatabase/database-darwin-arm64": "0.2.2", "@tursodatabase/database-linux-arm64-gnu": "0.2.2", "@tursodatabase/database-linux-x64-gnu": "0.2.2", "@tursodatabase/database-win32-x64-msvc": "0.2.2" } }, "sha512-BlvoyiwIWIIQA65KEYlCqLDpRKIOM1AN99tBMjz1B+ydO9h0cDb+lCbfBf6f7+Lk696KB1ODpePiF5EfGm9qpw=="],
 
@@ -207,25 +105,17 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
-
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
-
-    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
-
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "applesauce-common": ["applesauce-common@6.1.0", "", { "dependencies": { "@scure/base": "^1.2.4", "applesauce-core": "^6.1.0", "hash-sum": "^2.0.0", "light-bolt11-decoder": "^3.2.0", "nanoid": "^5.0.9", "rxjs": "^7.8.1" } }, "sha512-z5azXCIrSknGw57hzUN8F30Xd4clvLCfRQYM0asyyIQJtwxuEl0N/zrXX7RqdiJN/9yFCuLzBro2XoFezoeOMA=="],
 
@@ -249,13 +139,7 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
-
-    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
-
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -266,10 +150,6 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
-
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -289,13 +169,9 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
-
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
@@ -303,13 +179,9 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
-    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
-
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -325,23 +197,13 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
-
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
     "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
     "light-bolt11-decoder": ["light-bolt11-decoder@3.2.0", "", { "dependencies": { "@scure/base": "1.1.1" } }, "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ=="],
 
-    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
-
-    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
-
-    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
-
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
@@ -349,11 +211,7 @@
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
-    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
@@ -369,8 +227,6 @@
 
     "nostr-wasm": ["nostr-wasm@0.1.0", "", {}, "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA=="],
 
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
@@ -381,19 +237,7 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
-    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
-
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
-
-    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
-
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
-
-    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -407,29 +251,21 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
-
-    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "rollup": ["rollup@4.61.1", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.61.1", "@rollup/rollup-android-arm64": "4.61.1", "@rollup/rollup-darwin-arm64": "4.61.1", "@rollup/rollup-darwin-x64": "4.61.1", "@rollup/rollup-freebsd-arm64": "4.61.1", "@rollup/rollup-freebsd-x64": "4.61.1", "@rollup/rollup-linux-arm-gnueabihf": "4.61.1", "@rollup/rollup-linux-arm-musleabihf": "4.61.1", "@rollup/rollup-linux-arm64-gnu": "4.61.1", "@rollup/rollup-linux-arm64-musl": "4.61.1", "@rollup/rollup-linux-loong64-gnu": "4.61.1", "@rollup/rollup-linux-loong64-musl": "4.61.1", "@rollup/rollup-linux-ppc64-gnu": "4.61.1", "@rollup/rollup-linux-ppc64-musl": "4.61.1", "@rollup/rollup-linux-riscv64-gnu": "4.61.1", "@rollup/rollup-linux-riscv64-musl": "4.61.1", "@rollup/rollup-linux-s390x-gnu": "4.61.1", "@rollup/rollup-linux-x64-gnu": "4.61.1", "@rollup/rollup-linux-x64-musl": "4.61.1", "@rollup/rollup-openbsd-x64": "4.61.1", "@rollup/rollup-openharmony-arm64": "4.61.1", "@rollup/rollup-win32-arm64-msvc": "4.61.1", "@rollup/rollup-win32-ia32-msvc": "4.61.1", "@rollup/rollup-win32-x64-gnu": "4.61.1", "@rollup/rollup-win32-x64-msvc": "4.61.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+    "semver": ["semver@7.8.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -439,33 +275,15 @@
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
-    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
-
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
-
-    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
-
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
-
-    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
-
-    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
-
-    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -489,13 +307,9 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
+    "@cashu/coco-core/@cashu/cashu-ts": ["@cashu/cashu-ts@3.7.0", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-Jy4Hek+Wouh94xS4InmTJRLpBPXA6fddVOAHR5lfNyTsCk9r3desY0vnwUGvOZBZWsSKZXedqdD/YpjWb3zngQ=="],
+
     "@routstr/sdk/@cashu/cashu-ts": ["@cashu/cashu-ts@3.7.0", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-Jy4Hek+Wouh94xS4InmTJRLpBPXA6fddVOAHR5lfNyTsCk9r3desY0vnwUGvOZBZWsSKZXedqdD/YpjWb3zngQ=="],
-
-    "@routstr/sdk/@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
-
-    "@scure/bip39/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
-
-    "@scure/bip39/@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
 
     "applesauce-common/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
@@ -525,9 +339,7 @@
 
     "nostr-tools/@scure/bip32": ["@scure/bip32@2.0.1", "", { "dependencies": { "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA=="],
 
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
-
-    "@routstr/sdk/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "nostr-tools/@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
 
     "applesauce-common/applesauce-core/nostr-tools": ["nostr-tools@2.19.4", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg=="],
 
@@ -575,9 +387,13 @@
 
     "applesauce-core/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
 
+    "applesauce-core/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
     "applesauce-relay/nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "applesauce-relay/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
+
+    "applesauce-relay/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "applesauce-sqlite/applesauce-core/nostr-tools/@noble/ciphers": ["@noble/ciphers@0.5.3", "", {}, "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w=="],
 
@@ -607,12 +423,18 @@
 
     "applesauce-common/applesauce-core/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
 
+    "applesauce-common/applesauce-core/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
     "applesauce-sqlite/applesauce-core/nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "applesauce-sqlite/applesauce-core/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
 
+    "applesauce-sqlite/applesauce-core/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
     "applesauce-wallet-connect/applesauce-core/nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "applesauce-wallet-connect/applesauce-core/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
+
+    "applesauce-wallet-connect/applesauce-core/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   },
   "dependencies": {
     "@cashu/cashu-ts": "^4.3.0",
-    "@routstr/sdk": "file:../routstr-sdk",
+    "@cashu/coco-core": "^1.0.1",
+    "@cashu/coco-sqlite-bun": "^1.0.1",
+    "@routstr/sdk": "^0.3.9",
+    "@scure/bip39": "^2.2.0",
     "applesauce-core": "^5.1.0",
     "applesauce-relay": "^5.1.0",
     "applesauce-wallet-connect": "^6.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import {
   deleteClientAction,
   addClientAction,
 } from "./utils/clients";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { execSync } from "child_process";
 import {
   CONFIG_DIR,
@@ -29,12 +29,14 @@ import { logger } from "./utils/logger";
 import { setupIntegration, runIntegrationsForClients } from "./integrations";
 import { getClientsList } from "./utils/clients";
 import * as QRCode from "qrcode";
-import { normalizeNostrPubkey, npubFromPubkey, npubFromSecretKey } from "./utils/nip98";
-import { generateSecretKey, nip19 } from "nostr-tools";
 import {
-  isCocodInstalled,
-  resolveCocodExecutable,
-} from "./daemon/wallet/cocod-client";
+  normalizeNostrPubkey,
+  npubFromPubkey,
+  npubFromSecretKey,
+} from "./utils/nip98";
+import { generateSecretKey, nip19 } from "nostr-tools";
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
 import packageJson from "../package.json" with { type: "json" };
 
 type RoutstrModel = {
@@ -81,26 +83,28 @@ async function printLightningInvoice(invoice: string): Promise<void> {
   console.log(`${qr}\nInvoice:\n${invoice}`);
 }
 
-async function installCocodOrExit(): Promise<void> {
-  console.log("cocod not found. Installing globally with bun...");
+function initializeWallet(): void {
+  const walletDir =
+    process.env.COCOD_DIR ||
+    `${process.env.HOME || process.env.USERPROFILE || ""}/.cocod`;
+  const walletConfig = `${walletDir}/config.json`;
 
-  const installProc = Bun.spawn(
-    ["bun", "install", "--global", "@routstr/cocod"],
-    {
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
-
-  const installCode = await installProc.exited;
-  if (installCode !== 0 || !(await isCocodInstalled())) {
-    console.error(
-      "Failed to install cocod. Please run 'bun install --global @routstr/cocod' manually.",
-    );
-    throw new Error("cocod installation failed");
+  if (existsSync(walletConfig)) {
+    console.log("Wallet already initialized.");
+    return;
   }
 
-  console.log("cocod installed successfully.");
+  mkdirSync(walletDir, { recursive: true });
+  const mnemonic = generateMnemonic(wordlist);
+  const config = {
+    version: 1,
+    mnemonic,
+    encrypted: false,
+    createdAt: new Date().toISOString(),
+  };
+  writeFileSync(walletConfig, JSON.stringify(config, null, 2));
+  console.log("Initialized. Mnemonic:", mnemonic);
+  console.log("IMPORTANT: Write down this mnemonic and keep it safe!");
 }
 
 async function requireLocalDaemon(): Promise<void> {
@@ -144,75 +148,9 @@ async function initDaemon(): Promise<void> {
     console.log(`Your npub: ${npub}`);
     console.log(`You can view it in the config file at: ${CONFIG_FILE}\n`);
   }
-
-  if (!(await isCocodInstalled(config.cocodPath))) {
-    if (config.cocodPath) {
-      logger.error(
-        `Configured cocod executable was not found: ${config.cocodPath}`,
-      );
-      return;
-    }
-
-    await installCocodOrExit();
-  }
-
-  const cocodExecutable = resolveCocodExecutable(config.cocodPath);
-
+  
   console.log(`Database will be stored at: ${DB_PATH}`);
-  console.log("\nInitializing cocod...");
-
-  const initProc = Bun.spawn([cocodExecutable, "init"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  let initStdout = "";
-  let initStderr = "";
-
-  const stdoutDone = initProc.stdout
-    ? initProc.stdout.pipeTo(
-        new WritableStream<Uint8Array>({
-          write(chunk) {
-            const text = new TextDecoder().decode(chunk);
-            initStdout += text;
-            process.stdout.write(text);
-          },
-        }),
-      )
-    : Promise.resolve();
-
-  const stderrDone = initProc.stderr
-    ? initProc.stderr.pipeTo(
-        new WritableStream<Uint8Array>({
-          write(chunk) {
-            const text = new TextDecoder().decode(chunk);
-            initStderr += text;
-            process.stderr.write(text);
-          },
-        }),
-      )
-    : Promise.resolve();
-
-  const [initCode] = await Promise.all([
-    initProc.exited,
-    stdoutDone,
-    stderrDone,
-  ]);
-  const combinedOutput = `${initStdout}\n${initStderr}`.toLowerCase();
-  const alreadyInitialized = combinedOutput.includes("already initialized");
-
-  if (initCode !== 0 && !alreadyInitialized) {
-    console.error(
-      "Failed to initialize cocod. Please run 'cocod init' manually.",
-    );
-    return;
-  }
-
-  if (alreadyInitialized) {
-    console.log("cocod is already initialized.");
-  } else {
-    console.log("cocod initialized successfully.");
-  }
+  initializeWallet();
 
   await startDaemon({ port: String(config.port || 8008) });
 
@@ -243,36 +181,76 @@ program
     "Mint URL to refund to (defaults to first mint in wallet)",
   )
   .option("-y, --yes", "Skip confirmation prompt", false)
-  .option("--xcashu", "Refund xcashu tokens only (uses refundXcashuTokens)", false)
-  .action(async (options: { mintUrl?: string; yes: boolean; xcashu: boolean }) => {
-    await ensureDaemonRunning();
+  .option(
+    "--xcashu",
+    "Refund xcashu tokens only (uses refundXcashuTokens)",
+    false,
+  )
+  .action(
+    async (options: { mintUrl?: string; yes: boolean; xcashu: boolean }) => {
+      await ensureDaemonRunning();
 
-    let mintUrl = options.mintUrl;
-    if (!mintUrl) {
-      const balanceResult = await callDaemon("/balance");
-      if (balanceResult.error) {
-        console.log(balanceResult.error);
-        process.exit(1);
+      let mintUrl = options.mintUrl;
+      if (!mintUrl) {
+        const balanceResult = await callDaemon("/balance");
+        if (balanceResult.error) {
+          console.log(balanceResult.error);
+          process.exit(1);
+        }
+        const balances = (
+          balanceResult.output as
+            | {
+                balances?: Record<string, number>;
+              }
+            | undefined
+        )?.balances;
+        if (!balances || Object.keys(balances).length === 0) {
+          console.log("No mint URLs found in wallet balance");
+          process.exit(1);
+        }
+        mintUrl = Object.keys(balances)[0];
+        console.log(`Using mint URL: ${mintUrl}`);
       }
-      const balances = (
-        balanceResult.output as
-          | {
-              balances?: Record<string, number>;
+
+      try {
+        if (options.xcashu) {
+          // xcashu path: only refund xcashu tokens
+          const result = await callDaemon("/refund/xcashu", {
+            method: "POST",
+            body: { mintUrl },
+          });
+
+          if (result.error) {
+            console.log(result.error);
+            process.exit(1);
+          }
+
+          const output = result.output as
+            | {
+                message: string;
+                results: Array<{
+                  baseUrl: string;
+                  token: string;
+                  success: boolean;
+                  error?: string;
+                }>;
+              }
+            | undefined;
+
+          if (output) {
+            console.log(output.message);
+            console.log("\nResults:");
+            for (const r of output.results) {
+              const status = r.success
+                ? "success"
+                : `failed: ${r.error || "unknown"}`;
+              console.log(`  - ${r.baseUrl}: ${status}`);
             }
-          | undefined
-      )?.balances;
-      if (!balances || Object.keys(balances).length === 0) {
-        console.log("No mint URLs found in wallet balance");
-        process.exit(1);
-      }
-      mintUrl = Object.keys(balances)[0];
-      console.log(`Using mint URL: ${mintUrl}`);
-    }
+          }
+          return;
+        }
 
-    try {
-      if (options.xcashu) {
-        // xcashu path: only refund xcashu tokens
-        const result = await callDaemon("/refund/xcashu", {
+        const result = await callDaemon("/refund", {
           method: "POST",
           body: { mintUrl },
         });
@@ -285,68 +263,46 @@ program
         const output = result.output as
           | {
               message: string;
-              results: Array<{ baseUrl: string; token: string; success: boolean; error?: string }>;
+              pendingTokens: number;
+              apiKeys: number;
+              results: Array<{ baseUrl: string; success: boolean }>;
             }
           | undefined;
 
         if (output) {
           console.log(output.message);
+          console.log(`\nPending tokens: ${output.pendingTokens}`);
+          console.log(`API keys: ${output.apiKeys}`);
           console.log("\nResults:");
           for (const r of output.results) {
-            const status = r.success ? "success" : `failed: ${r.error || "unknown"}`;
-            console.log(`  - ${r.baseUrl}: ${status}`);
+            console.log(
+              `  - ${r.baseUrl}: ${r.success ? "success" : "failed"}`,
+            );
           }
         }
-        return;
-      }
-
-      const result = await callDaemon("/refund", {
-        method: "POST",
-        body: { mintUrl },
-      });
-
-      if (result.error) {
-        console.log(result.error);
-        process.exit(1);
-      }
-
-      const output = result.output as
-        | {
-            message: string;
-            pendingTokens: number;
-            apiKeys: number;
-            results: Array<{ baseUrl: string; success: boolean }>;
-          }
-        | undefined;
-
-      if (output) {
-        console.log(output.message);
-        console.log(`\nPending tokens: ${output.pendingTokens}`);
-        console.log(`API keys: ${output.apiKeys}`);
-        console.log("\nResults:");
-        for (const r of output.results) {
-          console.log(`  - ${r.baseUrl}: ${r.success ? "success" : "failed"}`);
+      } catch (error) {
+        const message = (error as Error).message;
+        if (
+          message?.includes("fetch failed") ||
+          message?.includes("Connection refused")
+        ) {
+          console.error("Daemon is not running");
+          process.exit(1);
         }
-      }
-    } catch (error) {
-      const message = (error as Error).message;
-      if (
-        message?.includes("fetch failed") ||
-        message?.includes("Connection refused")
-      ) {
-        console.error("Daemon is not running");
+        console.error(message);
         process.exit(1);
       }
-      console.error(message);
-      process.exit(1);
-    }
-  });
+    },
+  );
 
 // Remote - configure a remote daemon URL
 program
   .command("remote <url>")
   .description("Configure a remote daemon URL")
-  .option("--auth-url <authUrl>", "URL of the auth proxy for management commands (npubs, clients, usage)")
+  .option(
+    "--auth-url <authUrl>",
+    "URL of the auth proxy for management commands (npubs, clients, usage)",
+  )
   .action(async (url: string, options: { authUrl?: string }) => {
     try {
       new URL(url);
@@ -399,9 +355,7 @@ program
         `\nA new Nostr identity has been generated for remote authentication.`,
       );
       console.log(`Your npub: ${generatedNpub}`);
-      console.log(
-        `You can view it in the config file at: ${CONFIG_FILE}`,
-      );
+      console.log(`You can view it in the config file at: ${CONFIG_FILE}`);
     }
   });
 
@@ -425,13 +379,6 @@ program
   .action(async (options: { port?: string; provider?: string }) => {
     await requireLocalDaemon();
     const config = await loadConfig();
-    if (!(await isCocodInstalled(config.cocodPath))) {
-      const installHint = config.cocodPath
-        ? `Configured cocod executable was not found: ${config.cocodPath}`
-        : "cocod is not installed. Run 'routstrd onboard' first to install cocod.";
-      logger.error(installHint);
-      process.exit(1);
-    }
     await startDaemon({
       port: options.port || String(config.port || 8008),
       provider: options.provider,
@@ -923,7 +870,9 @@ npubsCmd
       : result;
     const npubs = (data as { npubs?: NpubEntry[] } | undefined)?.npubs ?? [];
     if (npubs.length === 0) {
-      console.log("No admin npubs configured. Run 'routstrd npubs register' to register yourself as the first admin.");
+      console.log(
+        "No admin npubs configured. Run 'routstrd npubs register' to register yourself as the first admin.",
+      );
       return;
     }
     console.log(`Npubs (${npubs.length}):`);
@@ -944,7 +893,9 @@ npubsCmd
 
 npubsCmd
   .command("register")
-  .description("Register yourself as the first admin (only when no admins exist)")
+  .description(
+    "Register yourself as the first admin (only when no admins exist)",
+  )
   .action(async () => {
     await ensureDaemonRunning();
     const config = await loadConfig();
@@ -965,7 +916,9 @@ npubsCmd
       : result;
     const npubs = (data as { npubs?: NpubEntry[] } | undefined)?.npubs ?? [];
     if (npubs.length > 0) {
-      console.log(`Admin npubs already configured (${npubs.length}). Ask your admin to add your npub. \n Your npub: ${userNpub}`);
+      console.log(
+        `Admin npubs already configured (${npubs.length}). Ask your admin to add your npub. \n Your npub: ${userNpub}`,
+      );
       return;
     }
     const normalized = normalizeNostrPubkey(userNpub);
@@ -985,7 +938,9 @@ npubsCmd
       | { npub?: string; added?: boolean; error?: string }
       | undefined;
     if (output?.npub) {
-      console.log(`Successfully registered as first admin npub: ${output.npub}`);
+      console.log(
+        `Successfully registered as first admin npub: ${output.npub}`,
+      );
     } else {
       console.log(`Successfully registered as first admin npub: ${userNpub}`);
     }
@@ -993,8 +948,14 @@ npubsCmd
 
 npubsCmd
   .command("add <npub>")
-  .description("Add a npub (hex pubkey or npub1...). Defaults to 'user' role unless --role is specified.")
-  .option("-r, --role <role>", "Role for the npub: 'admin' or 'user' (default: 'user')", "user")
+  .description(
+    "Add a npub (hex pubkey or npub1...). Defaults to 'user' role unless --role is specified.",
+  )
+  .option(
+    "-r, --role <role>",
+    "Role for the npub: 'admin' or 'user' (default: 'user')",
+    "user",
+  )
   .action(async (npubArg: string, options: { role: string }) => {
     await ensureDaemonRunning();
     const normalized = normalizeNostrPubkey(npubArg);
@@ -1006,7 +967,10 @@ npubsCmd
       console.error("Invalid role. Expected 'admin' or 'user'.");
       process.exit(1);
     }
-    const body: Record<string, string> = { npub: npubFromPubkey(normalized), role: options.role };
+    const body: Record<string, string> = {
+      npub: npubFromPubkey(normalized),
+      role: options.role,
+    };
     const result = await callAuth("/npubs", {
       method: "POST",
       body,
@@ -1323,7 +1287,10 @@ const nwcCmd = program
 nwcCmd
   .command("connect")
   .description("Connect to a Lightning wallet via NWC")
-  .argument("[connection-string]", "NWC connection string (nostr+walletconnect://...)")
+  .argument(
+    "[connection-string]",
+    "NWC connection string (nostr+walletconnect://...)",
+  )
   .action(async (connectionString?: string) => {
     if (!connectionString) {
       // Interactive mode: prompt for connection string
@@ -1340,8 +1307,14 @@ nwcCmd
     }
 
     // Quick validation: must be nostr+walletconnect:// with a 64-char hex pubkey
-    if (!/^nostr\+walletconnect:\/\/[0-9a-fA-F]{64}\?relay=/.test(connectionString)) {
-      console.error("Invalid NWC connection string: expected nostr+walletconnect://<64-char-hex>?relay=...");
+    if (
+      !/^nostr\+walletconnect:\/\/[0-9a-fA-F]{64}\?relay=/.test(
+        connectionString,
+      )
+    ) {
+      console.error(
+        "Invalid NWC connection string: expected nostr+walletconnect://<64-char-hex>?relay=...",
+      );
       process.exit(1);
     }
 
@@ -1396,21 +1369,27 @@ autoRefillCmd
     "Minimum time between refills in seconds",
     "300",
   )
-  .action(async (options: { threshold: string; amount: string; cooldown: string }) => {
-    const threshold = parsePositiveIntOrExit(options.threshold, "threshold");
-    const amount = parsePositiveIntOrExit(options.amount, "amount");
-    const cooldownSec = parsePositiveIntOrExit(options.cooldown, "cooldown");
+  .action(
+    async (options: {
+      threshold: string;
+      amount: string;
+      cooldown: string;
+    }) => {
+      const threshold = parsePositiveIntOrExit(options.threshold, "threshold");
+      const amount = parsePositiveIntOrExit(options.amount, "amount");
+      const cooldownSec = parsePositiveIntOrExit(options.cooldown, "cooldown");
 
-    await handleDaemonCommand("/nwc/auto-refill", {
-      method: "POST",
-      body: {
-        enabled: true,
-        threshold,
-        amount,
-        cooldownMs: cooldownSec * 1000,
-      },
-    });
-  });
+      await handleDaemonCommand("/nwc/auto-refill", {
+        method: "POST",
+        body: {
+          enabled: true,
+          threshold,
+          amount,
+          cooldownMs: cooldownSec * 1000,
+        },
+      });
+    },
+  );
 
 autoRefillCmd
   .command("off")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,11 +29,7 @@ import { logger } from "./utils/logger";
 import { setupIntegration, runIntegrationsForClients } from "./integrations";
 import { getClientsList } from "./utils/clients";
 import * as QRCode from "qrcode";
-import {
-  normalizeNostrPubkey,
-  npubFromPubkey,
-  npubFromSecretKey,
-} from "./utils/nip98";
+import { normalizeNostrPubkey, npubFromPubkey, npubFromSecretKey } from "./utils/nip98";
 import { generateSecretKey, nip19 } from "nostr-tools";
 import { generateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
@@ -88,12 +84,10 @@ function initializeWallet(): void {
     process.env.COCOD_DIR ||
     `${process.env.HOME || process.env.USERPROFILE || ""}/.cocod`;
   const walletConfig = `${walletDir}/config.json`;
-
   if (existsSync(walletConfig)) {
     console.log("Wallet already initialized.");
     return;
   }
-
   mkdirSync(walletDir, { recursive: true });
   const mnemonic = generateMnemonic(wordlist);
   const config = {
@@ -148,7 +142,7 @@ async function initDaemon(): Promise<void> {
     console.log(`Your npub: ${npub}`);
     console.log(`You can view it in the config file at: ${CONFIG_FILE}\n`);
   }
-  
+
   console.log(`Database will be stored at: ${DB_PATH}`);
   initializeWallet();
 
@@ -181,76 +175,36 @@ program
     "Mint URL to refund to (defaults to first mint in wallet)",
   )
   .option("-y, --yes", "Skip confirmation prompt", false)
-  .option(
-    "--xcashu",
-    "Refund xcashu tokens only (uses refundXcashuTokens)",
-    false,
-  )
-  .action(
-    async (options: { mintUrl?: string; yes: boolean; xcashu: boolean }) => {
-      await ensureDaemonRunning();
+  .option("--xcashu", "Refund xcashu tokens only (uses refundXcashuTokens)", false)
+  .action(async (options: { mintUrl?: string; yes: boolean; xcashu: boolean }) => {
+    await ensureDaemonRunning();
 
-      let mintUrl = options.mintUrl;
-      if (!mintUrl) {
-        const balanceResult = await callDaemon("/balance");
-        if (balanceResult.error) {
-          console.log(balanceResult.error);
-          process.exit(1);
-        }
-        const balances = (
-          balanceResult.output as
-            | {
-                balances?: Record<string, number>;
-              }
-            | undefined
-        )?.balances;
-        if (!balances || Object.keys(balances).length === 0) {
-          console.log("No mint URLs found in wallet balance");
-          process.exit(1);
-        }
-        mintUrl = Object.keys(balances)[0];
-        console.log(`Using mint URL: ${mintUrl}`);
+    let mintUrl = options.mintUrl;
+    if (!mintUrl) {
+      const balanceResult = await callDaemon("/balance");
+      if (balanceResult.error) {
+        console.log(balanceResult.error);
+        process.exit(1);
       }
-
-      try {
-        if (options.xcashu) {
-          // xcashu path: only refund xcashu tokens
-          const result = await callDaemon("/refund/xcashu", {
-            method: "POST",
-            body: { mintUrl },
-          });
-
-          if (result.error) {
-            console.log(result.error);
-            process.exit(1);
-          }
-
-          const output = result.output as
-            | {
-                message: string;
-                results: Array<{
-                  baseUrl: string;
-                  token: string;
-                  success: boolean;
-                  error?: string;
-                }>;
-              }
-            | undefined;
-
-          if (output) {
-            console.log(output.message);
-            console.log("\nResults:");
-            for (const r of output.results) {
-              const status = r.success
-                ? "success"
-                : `failed: ${r.error || "unknown"}`;
-              console.log(`  - ${r.baseUrl}: ${status}`);
+      const balances = (
+        balanceResult.output as
+          | {
+              balances?: Record<string, number>;
             }
-          }
-          return;
-        }
+          | undefined
+      )?.balances;
+      if (!balances || Object.keys(balances).length === 0) {
+        console.log("No mint URLs found in wallet balance");
+        process.exit(1);
+      }
+      mintUrl = Object.keys(balances)[0];
+      console.log(`Using mint URL: ${mintUrl}`);
+    }
 
-        const result = await callDaemon("/refund", {
+    try {
+      if (options.xcashu) {
+        // xcashu path: only refund xcashu tokens
+        const result = await callDaemon("/refund/xcashu", {
           method: "POST",
           body: { mintUrl },
         });
@@ -263,46 +217,68 @@ program
         const output = result.output as
           | {
               message: string;
-              pendingTokens: number;
-              apiKeys: number;
-              results: Array<{ baseUrl: string; success: boolean }>;
+              results: Array<{ baseUrl: string; token: string; success: boolean; error?: string }>;
             }
           | undefined;
 
         if (output) {
           console.log(output.message);
-          console.log(`\nPending tokens: ${output.pendingTokens}`);
-          console.log(`API keys: ${output.apiKeys}`);
           console.log("\nResults:");
           for (const r of output.results) {
-            console.log(
-              `  - ${r.baseUrl}: ${r.success ? "success" : "failed"}`,
-            );
+            const status = r.success ? "success" : `failed: ${r.error || "unknown"}`;
+            console.log(`  - ${r.baseUrl}: ${status}`);
           }
         }
-      } catch (error) {
-        const message = (error as Error).message;
-        if (
-          message?.includes("fetch failed") ||
-          message?.includes("Connection refused")
-        ) {
-          console.error("Daemon is not running");
-          process.exit(1);
-        }
-        console.error(message);
+        return;
+      }
+
+      const result = await callDaemon("/refund", {
+        method: "POST",
+        body: { mintUrl },
+      });
+
+      if (result.error) {
+        console.log(result.error);
         process.exit(1);
       }
-    },
-  );
+
+      const output = result.output as
+        | {
+            message: string;
+            pendingTokens: number;
+            apiKeys: number;
+            results: Array<{ baseUrl: string; success: boolean }>;
+          }
+        | undefined;
+
+      if (output) {
+        console.log(output.message);
+        console.log(`\nPending tokens: ${output.pendingTokens}`);
+        console.log(`API keys: ${output.apiKeys}`);
+        console.log("\nResults:");
+        for (const r of output.results) {
+          console.log(`  - ${r.baseUrl}: ${r.success ? "success" : "failed"}`);
+        }
+      }
+    } catch (error) {
+      const message = (error as Error).message;
+      if (
+        message?.includes("fetch failed") ||
+        message?.includes("Connection refused")
+      ) {
+        console.error("Daemon is not running");
+        process.exit(1);
+      }
+      console.error(message);
+      process.exit(1);
+    }
+  });
 
 // Remote - configure a remote daemon URL
 program
   .command("remote <url>")
   .description("Configure a remote daemon URL")
-  .option(
-    "--auth-url <authUrl>",
-    "URL of the auth proxy for management commands (npubs, clients, usage)",
-  )
+  .option("--auth-url <authUrl>", "URL of the auth proxy for management commands (npubs, clients, usage)")
   .action(async (url: string, options: { authUrl?: string }) => {
     try {
       new URL(url);
@@ -355,7 +331,9 @@ program
         `\nA new Nostr identity has been generated for remote authentication.`,
       );
       console.log(`Your npub: ${generatedNpub}`);
-      console.log(`You can view it in the config file at: ${CONFIG_FILE}`);
+      console.log(
+        `You can view it in the config file at: ${CONFIG_FILE}`,
+      );
     }
   });
 
@@ -870,9 +848,7 @@ npubsCmd
       : result;
     const npubs = (data as { npubs?: NpubEntry[] } | undefined)?.npubs ?? [];
     if (npubs.length === 0) {
-      console.log(
-        "No admin npubs configured. Run 'routstrd npubs register' to register yourself as the first admin.",
-      );
+      console.log("No admin npubs configured. Run 'routstrd npubs register' to register yourself as the first admin.");
       return;
     }
     console.log(`Npubs (${npubs.length}):`);
@@ -893,9 +869,7 @@ npubsCmd
 
 npubsCmd
   .command("register")
-  .description(
-    "Register yourself as the first admin (only when no admins exist)",
-  )
+  .description("Register yourself as the first admin (only when no admins exist)")
   .action(async () => {
     await ensureDaemonRunning();
     const config = await loadConfig();
@@ -916,9 +890,7 @@ npubsCmd
       : result;
     const npubs = (data as { npubs?: NpubEntry[] } | undefined)?.npubs ?? [];
     if (npubs.length > 0) {
-      console.log(
-        `Admin npubs already configured (${npubs.length}). Ask your admin to add your npub. \n Your npub: ${userNpub}`,
-      );
+      console.log(`Admin npubs already configured (${npubs.length}). Ask your admin to add your npub. \n Your npub: ${userNpub}`);
       return;
     }
     const normalized = normalizeNostrPubkey(userNpub);
@@ -938,9 +910,7 @@ npubsCmd
       | { npub?: string; added?: boolean; error?: string }
       | undefined;
     if (output?.npub) {
-      console.log(
-        `Successfully registered as first admin npub: ${output.npub}`,
-      );
+      console.log(`Successfully registered as first admin npub: ${output.npub}`);
     } else {
       console.log(`Successfully registered as first admin npub: ${userNpub}`);
     }
@@ -948,14 +918,8 @@ npubsCmd
 
 npubsCmd
   .command("add <npub>")
-  .description(
-    "Add a npub (hex pubkey or npub1...). Defaults to 'user' role unless --role is specified.",
-  )
-  .option(
-    "-r, --role <role>",
-    "Role for the npub: 'admin' or 'user' (default: 'user')",
-    "user",
-  )
+  .description("Add a npub (hex pubkey or npub1...). Defaults to 'user' role unless --role is specified.")
+  .option("-r, --role <role>", "Role for the npub: 'admin' or 'user' (default: 'user')", "user")
   .action(async (npubArg: string, options: { role: string }) => {
     await ensureDaemonRunning();
     const normalized = normalizeNostrPubkey(npubArg);
@@ -967,10 +931,7 @@ npubsCmd
       console.error("Invalid role. Expected 'admin' or 'user'.");
       process.exit(1);
     }
-    const body: Record<string, string> = {
-      npub: npubFromPubkey(normalized),
-      role: options.role,
-    };
+    const body: Record<string, string> = { npub: npubFromPubkey(normalized), role: options.role };
     const result = await callAuth("/npubs", {
       method: "POST",
       body,
@@ -1287,10 +1248,7 @@ const nwcCmd = program
 nwcCmd
   .command("connect")
   .description("Connect to a Lightning wallet via NWC")
-  .argument(
-    "[connection-string]",
-    "NWC connection string (nostr+walletconnect://...)",
-  )
+  .argument("[connection-string]", "NWC connection string (nostr+walletconnect://...)")
   .action(async (connectionString?: string) => {
     if (!connectionString) {
       // Interactive mode: prompt for connection string
@@ -1307,14 +1265,8 @@ nwcCmd
     }
 
     // Quick validation: must be nostr+walletconnect:// with a 64-char hex pubkey
-    if (
-      !/^nostr\+walletconnect:\/\/[0-9a-fA-F]{64}\?relay=/.test(
-        connectionString,
-      )
-    ) {
-      console.error(
-        "Invalid NWC connection string: expected nostr+walletconnect://<64-char-hex>?relay=...",
-      );
+    if (!/^nostr\+walletconnect:\/\/[0-9a-fA-F]{64}\?relay=/.test(connectionString)) {
+      console.error("Invalid NWC connection string: expected nostr+walletconnect://<64-char-hex>?relay=...");
       process.exit(1);
     }
 
@@ -1369,27 +1321,21 @@ autoRefillCmd
     "Minimum time between refills in seconds",
     "300",
   )
-  .action(
-    async (options: {
-      threshold: string;
-      amount: string;
-      cooldown: string;
-    }) => {
-      const threshold = parsePositiveIntOrExit(options.threshold, "threshold");
-      const amount = parsePositiveIntOrExit(options.amount, "amount");
-      const cooldownSec = parsePositiveIntOrExit(options.cooldown, "cooldown");
+  .action(async (options: { threshold: string; amount: string; cooldown: string }) => {
+    const threshold = parsePositiveIntOrExit(options.threshold, "threshold");
+    const amount = parsePositiveIntOrExit(options.amount, "amount");
+    const cooldownSec = parsePositiveIntOrExit(options.cooldown, "cooldown");
 
-      await handleDaemonCommand("/nwc/auto-refill", {
-        method: "POST",
-        body: {
-          enabled: true,
-          threshold,
-          amount,
-          cooldownMs: cooldownSec * 1000,
-        },
-      });
-    },
-  );
+    await handleDaemonCommand("/nwc/auto-refill", {
+      method: "POST",
+      body: {
+        enabled: true,
+        threshold,
+        amount,
+        cooldownMs: cooldownSec * 1000,
+      },
+    });
+  });
 
 autoRefillCmd
   .command("off")

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -33,11 +33,11 @@ import {
 } from "@routstr/sdk/storage/bun";
 import { createWalletAdapter } from "./wallet";
 import type { AutoRefillConfig } from "./wallet/auto-refill";
-import { createCocodClient } from "./wallet/cocod-client";
 import { createModelService } from "./models";
 import { createDaemonRequestHandler } from "./http";
 import { refreshModelsAndIntegrations } from "../integrations";
 import { RoutstrClient } from "@routstr/sdk";
+import { createCocoClient } from "./wallet/coco-client";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
   const { ensureProvidersBootstrapped, getRoutstr21Models, getModelProviders, refreshProvidersAndModels } =
     createModelService(modelManager, store);
 
-  const walletClient = createCocodClient({ cocodPath: config.cocodPath });
+  const walletClient = await createCocoClient();
 
   // ── Auto-refill configuration ────────────────────────────────
   // Uses a getter that reads config from disk each cycle, so

--- a/src/daemon/wallet/coco-client.ts
+++ b/src/daemon/wallet/coco-client.ts
@@ -60,9 +60,12 @@ export async function createCocoClient(): Promise<CocodClient> {
     },
 
     async getStatus(): Promise<CocodState> {
-      // coco-core has no lock/unlock concept, the wallet is always
-      // ready once initialized. Return UNLOCKED to satisfy the interface.
-      return "UNLOCKED";
+      try {
+        await coco.wallet.balances.total();
+        return "UNLOCKED";
+      } catch {
+        return "ERROR";
+      }
     },
 
     async unlock(_passphrase: string): Promise<string> {
@@ -97,8 +100,10 @@ export async function createCocoClient(): Promise<CocodClient> {
         amount,
         method: "bolt11",
       });
-      // PendingMintOperation extends MintQuoteSnapshot which has `request`
-      return (op as unknown as { request: string }).request;
+      if (!("request" in op)) {
+        throw new Error("mint prepare did not return a payment request");
+      }
+      return op.request as string;
     },
 
     async sendCashu(amount: number, mintUrl?: string): Promise<string> {
@@ -111,8 +116,13 @@ export async function createCocoClient(): Promise<CocodClient> {
         mintUrl: targetMint,
         amount,
       });
-      const { token } = await coco.ops.send.execute(prepared);
-      return getEncodedToken(token);
+      try {
+        const { token } = await coco.ops.send.execute(prepared.id);
+        return getEncodedToken(token);
+      } catch (error) {
+        await coco.ops.send.cancel(prepared.id);
+        throw error;
+      }
     },
 
     async sendBolt11(invoice: string, mintUrl?: string): Promise<string> {
@@ -121,16 +131,22 @@ export async function createCocoClient(): Promise<CocodClient> {
       if (!targetMint) {
         throw new Error("No trusted mint available for Lightning payment");
       }
-      await coco.ops.melt.prepare({
+      const prepared = await coco.ops.melt.prepare({
         mintUrl: targetMint,
         method: "bolt11",
         methodData: { invoice },
       });
-      return "Payment initiated successfully";
+      try {
+        await coco.ops.melt.execute(prepared.id);
+        return "Payment sent successfully";
+      } catch (error) {
+        await coco.ops.melt.cancel(prepared.id);
+        throw error;
+      }
     },
 
     async listMints(): Promise<string[]> {
-      const mints = await coco.mint.getAllMints();
+      const mints = await coco.mint.getAllTrustedMints();
       return mints.map((m) => m.mintUrl);
     },
 

--- a/src/daemon/wallet/coco-client.ts
+++ b/src/daemon/wallet/coco-client.ts
@@ -1,0 +1,142 @@
+import { initializeCoco, getEncodedToken } from "@cashu/coco-core";
+import { SqliteRepositories } from "@cashu/coco-sqlite-bun";
+import { Database } from "bun:sqlite";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { mnemonicToSeedSync } from "@scure/bip39";
+import type { CocodClient, CocodState } from "./cocod-client";
+import { logger } from "../../utils/logger";
+
+const CONFIG_DIR =
+  process.env.COCOD_DIR ||
+  `${process.env.HOME || process.env.USERPROFILE || ""}/.cocod`;
+
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+const DB_PATH = join(CONFIG_DIR, "coco.db");
+
+interface CocodConfig {
+  mnemonic: string;
+  encrypted: boolean;
+}
+
+function loadMnemonic(): string {
+  if (!existsSync(CONFIG_FILE)) {
+    throw new Error(
+      `Config file not found at ${CONFIG_FILE}. Run 'routstrd onboard' first.`,
+    );
+  }
+  const config = JSON.parse(readFileSync(CONFIG_FILE, "utf-8")) as CocodConfig;
+  if (config.encrypted) {
+    throw new Error(
+      "Encrypted wallets are not supported yet. Please use an unencrypted wallet.",
+    );
+  }
+  return config.mnemonic;
+}
+
+async function seedGetter(): Promise<Uint8Array> {
+  const mnemonic = loadMnemonic();
+  return mnemonicToSeedSync(mnemonic);
+}
+
+export async function createCocoClient(): Promise<CocodClient> {
+  const database = new Database(DB_PATH);
+  const repo = new SqliteRepositories({ database });
+  await repo.init();
+
+  const coco = await initializeCoco({
+    repo,
+    seedGetter,
+  });
+
+  return {
+    async ping(): Promise<boolean> {
+      try {
+        await coco.wallet.balances.total();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async getStatus(): Promise<CocodState> {
+      return "UNLOCKED";
+    },
+
+    async unlock(_passphrase: string): Promise<string> {
+      return "already unlocked";
+    },
+
+    async getBalances(): Promise<Record<string, number>> {
+      const byMint = await coco.wallet.balances.byMint();
+      return Object.fromEntries(
+        Object.entries(byMint).map(([mintUrl, snapshot]) => [
+          mintUrl,
+          snapshot.spendable,
+        ]),
+      );
+    },
+
+    async receiveCashu(token: string): Promise<string> {
+      await coco.wallet.receive(token);
+      return "Token received successfully";
+    },
+
+    async receiveBolt11(amount: number, mintUrl?: string): Promise<string> {
+      const mints = await coco.mint.getAllTrustedMints();
+      const targetMint = mintUrl || mints[0]?.mintUrl;
+      if (!targetMint) {
+        throw new Error("No trusted mint available for Lightning invoice");
+      }
+      const op = await coco.ops.mint.prepare({
+        mintUrl: targetMint,
+        amount,
+        method: "bolt11",
+      });
+      // PendingMintOperation extends MintQuoteSnapshot which has `request`
+      return (op as unknown as { request: string }).request;
+    },
+
+    async sendCashu(amount: number, mintUrl?: string): Promise<string> {
+      const mints = await coco.mint.getAllTrustedMints();
+      const targetMint = mintUrl || mints[0]?.mintUrl;
+      if (!targetMint) {
+        throw new Error("No trusted mint available for sending");
+      }
+      const prepared = await coco.ops.send.prepare({
+        mintUrl: targetMint,
+        amount,
+      });
+      const { token } = await coco.ops.send.execute(prepared);
+      return getEncodedToken(token);
+    },
+
+    async sendBolt11(invoice: string, mintUrl?: string): Promise<string> {
+      const mints = await coco.mint.getAllTrustedMints();
+      const targetMint = mintUrl || mints[0]?.mintUrl;
+      if (!targetMint) {
+        throw new Error("No trusted mint available for Lightning payment");
+      }
+      await coco.ops.melt.prepare({
+        mintUrl: targetMint,
+        method: "bolt11",
+        methodData: { invoice },
+      });
+      return "Payment initiated successfully";
+    },
+
+    async listMints(): Promise<string[]> {
+      const mints = await coco.mint.getAllMints();
+      return mints.map((m) => m.mintUrl);
+    },
+
+    async addMint(url: string): Promise<string> {
+      await coco.mint.addMint(url, { trusted: true });
+      return `Mint ${url} added successfully`;
+    },
+
+    async getMintInfo(url: string): Promise<unknown> {
+      return coco.mint.getMintInfo(url);
+    },
+  };
+}

--- a/src/daemon/wallet/coco-client.ts
+++ b/src/daemon/wallet/coco-client.ts
@@ -60,11 +60,15 @@ export async function createCocoClient(): Promise<CocodClient> {
     },
 
     async getStatus(): Promise<CocodState> {
+      // coco-core has no lock/unlock concept, the wallet is always
+      // ready once initialized. Return UNLOCKED to satisfy the interface.
       return "UNLOCKED";
     },
 
     async unlock(_passphrase: string): Promise<string> {
-      return "already unlocked";
+      // coco-core does not support passphrase locking.
+      // Wallet access is controlled via the mnemonic in ~/.cocod/config.json.
+      return "wallet does not require unlocking";
     },
 
     async getBalances(): Promise<Record<string, number>> {


### PR DESCRIPTION
Previously routstrd relied on cocod - a separate Cashu wallet daemon for all wallet operations. 

## Before
routstrd spawns cocod process, talks to it over `~/.cocod/cocod.sock`  
cocod manages the wallet and reads/writes to `~/.cocod/coco.db`

routstrd -> cocod (separate process, Unix socket) -> ~/.cocod/coco.db

## After
routstrd uses coco-core library directly in the same process  
reads mnemonic from `~/.cocod/config.json`, same db at `~/.cocod/coco.db`  
no separate process, no socket communication

routstrd -> coco-core (same process) -> ~/.cocod/coco.db

Same wallet data, no separate process needed.

## Changes

- added `src/daemon/wallet/coco-client.ts` which implements the existing 
  `CocodClient` interface using `@cashu/coco-core` and `@cashu/coco-sqlite-bun`
- updated `daemon/index.ts` to use `createCocoClient()` instead of `createCocodClient()`
- `onboard` no longer installs `@routstr/cocod` or runs `cocod init`, 
  generates the mnemonic directly using `@scure/bip39` and saves it 
  to `~/.cocod/config.json` in the same format
- `start` command no longer checks if cocod is installed

## New dependencies
- `@cashu/coco-core`
- `@cashu/coco-sqlite-bun`  
- `@scure/bip39`

## Tested
onboard flow, balance reads, and ai requests all working