### PR TITLE
Display usage timestamps in local time instead of UTC

### DIFF
--- a/src/tui/usage/data.ts
+++ b/src/tui/usage/data.ts
@@ -118,11 +118,15 @@ export function getTodayStart(): number {
 }
 
 export function formatDate(timestamp: number): string {
-  return new Date(timestamp).toISOString().split("T")[0] ?? "";
+  const d = new Date(timestamp);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
 export function formatTime(timestamp: number): string {
-  return new Date(timestamp).toISOString().split("T")[1]?.slice(0, 8) ?? "";
+  const d = new Date(timestamp);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 
 export function formatNumber(n: number): string {


### PR DESCRIPTION
### Summary

The usage monitor (`routstrd monitor`) displayed request timestamps in UTC, so the times never matched the user's wall clock. This switches the monitor's date and time formatting to local time.

### The change

In `src/tui/usage/data.ts`, `formatDate` and `formatTime` now build their strings from local-time getters (`getFullYear`/`getHours`/etc.) instead of `toISOString()`.

While the issue mentioned just time, I figured applying the same change to `formatDate` makes sense here since it is used as the grouping key for the daily-stats map.


Closes #5.