### PR TITLE
fix: exclude failed mint from fallback candidate selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routstrd",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "module": "src/index.ts",
   "type": "module",
   "private": false,

--- a/src/daemon/http/index.ts
+++ b/src/daemon/http/index.ts
@@ -16,6 +16,7 @@ import {
   type CocodState,
 } from "../wallet/cocod-client";
 import { decodeCashuTokenAmount } from "../wallet";
+import { receiveBolt11WithMintFallback } from "../wallet/mint-fallback";
 import { getClientsFromStore } from "../../utils/clients";
 import { getUsageSummary } from "./usage-summary";
 
@@ -47,6 +48,7 @@ type DaemonDeps = {
   /** Nostr hex pubkey for routstr review/model events (kind 38425/38423). */
   routstrPubkey?: string;
   providerManager: ProviderManager;
+  routeClient: any;
   refundClient: any;
   requestResponseLogSink?: RequestResponseLogSink;
 };
@@ -302,6 +304,7 @@ export function createDaemonRequestHandler(deps: {
   routstrPubkey?: string;
   usageTrackingDriver: UsageTrackingDriver;
   providerManager: ProviderManager;
+  routeClient: any;
   refundClient: any;
   requestResponseLogSink?: RequestResponseLogSink;
 }) {
@@ -373,8 +376,24 @@ export function createDaemonRequestHandler(deps: {
       await respond(res, async () => {
         const body = await readJsonBody(req);
         const amount = getRequiredPositiveNumberField(body, "amount");
-        const mintUrl = optionalStringField(body, "mintUrl");
-        const invoice = await deps.walletClient.receiveBolt11(amount, mintUrl);
+        const requestedMintUrl = optionalStringField(body, "mintUrl");
+        let invoice: string;
+        let mintUrl: string | undefined = requestedMintUrl;
+
+        if (requestedMintUrl) {
+          invoice = await deps.walletClient.receiveBolt11(amount, requestedMintUrl);
+        } else {
+          const mints = await deps.walletClient.listMints();
+          const result = await receiveBolt11WithMintFallback(
+            deps.walletClient,
+            amount,
+            mints,
+            "[wallet]",
+          );
+          invoice = result.invoice;
+          mintUrl = result.mintUrl;
+        }
+
         return { output: { invoice, amount, mintUrl } };
       });
       return;
@@ -1273,6 +1292,7 @@ export function createDaemonRequestHandler(deps: {
         usageTrackingDriver: deps.usageTrackingDriver,
         sdkStore: deps.store,
         providerManager: deps.providerManager,
+        client: deps.routeClient,
         logger: reqLogger,
         ...(deps.requestResponseLogSink
           ? { requestResponseLogSink: deps.requestResponseLogSink }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -43,6 +43,7 @@ import {
 import { createWalletAdapter } from "./wallet";
 import type { AutoRefillConfig } from "./wallet/auto-refill";
 import { createCocodClient } from "./wallet/cocod-client";
+import { installMintFallbackTopUp } from "./wallet/sdk-mint-fallback";
 import { createModelService } from "./models";
 import { createDaemonRequestHandler } from "./http";
 import { FileRequestResponseLogSink } from "./request-response-log-sink";
@@ -129,6 +130,22 @@ async function main(): Promise<void> {
     nwcConnectionString: config.nwc?.connectionString,
   });
 
+  const routeClient = new RoutstrClient(
+    walletAdapter,
+    storageAdapter,
+    discoveryAdapter,
+    "min",
+    config.mode || "apikeys",
+    {
+      usageTrackingDriver,
+      sdkStore: store,
+      providerManager,
+      logger: daemonSdkLogger,
+      requestResponseLogSink,
+    },
+  );
+  installMintFallbackTopUp(routeClient, walletClient, walletAdapter, daemonSdkLogger);
+
   const refundClient = new RoutstrClient(
     walletAdapter,
     storageAdapter,
@@ -158,6 +175,7 @@ async function main(): Promise<void> {
       routstrPubkey: config.routstrPubkey,
       usageTrackingDriver,
       providerManager,
+      routeClient,
       refundClient,
       requestResponseLogSink,
     }),

--- a/src/daemon/wallet/auto-refill.ts
+++ b/src/daemon/wallet/auto-refill.ts
@@ -7,6 +7,7 @@
 import type { CocodClient } from "./cocod-client";
 import type { WalletConnect } from "applesauce-wallet-connect";
 import { logger } from "../../utils/logger";
+import { receiveBolt11WithMintFallback } from "./mint-fallback";
 
 export interface AutoRefillConfig {
   /** Minimum sats balance before triggering a refill */
@@ -94,19 +95,24 @@ export function startAutoRefillLoop(
         `[auto-refill] Balance ${totalBalance} sats < threshold ${config.threshold}. Refilling ${config.amount} sats...`,
       );
 
-      // Get active mint
+      // Get configured mints. If the active mint is unreachable, fall back to
+      // later configured mints before giving up.
       const mints = await cocod.listMints();
-      const mintUrl = mints[0];
-      if (!mintUrl) {
+      if (mints.length === 0) {
         logger.error("[auto-refill] No active mint configured");
         return;
       }
 
       // Step 1: Create a BOLT-11 invoice via cocod to fund the Cashu wallet
       logger.log(
-        `[auto-refill] Creating BOLT-11 invoice for ${config.amount} sats via ${mintUrl}...`,
+        `[auto-refill] Creating BOLT-11 invoice for ${config.amount} sats via ${mints[0]}...`,
       );
-      const invoice = await cocod.receiveBolt11(config.amount, mintUrl);
+      const { invoice, mintUrl } = await receiveBolt11WithMintFallback(
+        cocod,
+        config.amount,
+        mints,
+        "[auto-refill]",
+      );
 
       // Step 2: Pay the invoice via NWC (applesauce)
       logger.log(`[auto-refill] Paying invoice via NWC...`);

--- a/src/daemon/wallet/index.ts
+++ b/src/daemon/wallet/index.ts
@@ -5,6 +5,7 @@ import { RelayPool } from "applesauce-relay";
 import { logger } from "../../utils/logger";
 import { createCocodClient, type CocodClient } from "./cocod-client";
 import { startAutoRefillLoop, type AutoRefillConfig } from "./auto-refill";
+import { receiveBolt11WithMintFallback } from "./mint-fallback";
 
 export function decodeCashuTokenAmount(token: string): {
   amount: number;
@@ -151,16 +152,33 @@ export async function createWalletAdapter(
         return { success: false, invoice: "", error: "NWC not connected" };
       }
 
-      // Ensure we have an active mint
+      // Ensure we have configured mints. If the active mint is unreachable,
+      // invoice creation will fall back to later configured mints.
       await syncMintState();
-      const mintUrl = activeMintUrl;
-      if (!mintUrl) {
+      const configuredMints = await client.listMints();
+      const mintCandidates = [activeMintUrl, ...configuredMints].filter(
+        (mintUrl): mintUrl is string => typeof mintUrl === "string" && mintUrl.length > 0,
+      );
+      if (mintCandidates.length === 0) {
         logger.error("[nwc] No active mint configured");
         return { success: false, invoice: "", error: "No active mint configured" };
       }
 
       try {
-        // Step 1: Check initial balance
+        // Step 1: Create a BOLT-11 invoice via cocod
+        logger.log(`[nwc] Creating ${amount}-sat Lightning invoice via cocod...`);
+        const { invoice, mintUrl } = await receiveBolt11WithMintFallback(
+          client,
+          amount,
+          mintCandidates,
+          "[nwc]",
+        );
+        logger.log(`[nwc]   Invoice: ${invoice}`);
+        if (mintUrl !== activeMintUrl) {
+          logger.log(`[nwc]   Using fallback mint: ${mintUrl}`);
+        }
+
+        // Step 2: Check initial balance
         logger.log(`[nwc] Checking initial cocod balance on mint ${mintUrl}...`);
         let initialBalance: number | null = null;
         try {
@@ -170,11 +188,6 @@ export async function createWalletAdapter(
         } catch {
           logger.log("[nwc]   Could not retrieve initial balance");
         }
-
-        // Step 2: Create a BOLT-11 invoice via cocod
-        logger.log(`[nwc] Creating ${amount}-sat Lightning invoice via cocod...`);
-        const invoice = await client.receiveBolt11(amount, mintUrl);
-        logger.log(`[nwc]   Invoice: ${invoice}`);
 
         // Step 3: Pay it via NWC
         logger.log("[nwc] Paying invoice via NWC...");

--- a/src/daemon/wallet/index.ts
+++ b/src/daemon/wallet/index.ts
@@ -1,5 +1,4 @@
 import { getDecodedToken, Amount } from "@cashu/cashu-ts";
-import { InsufficientBalanceError } from "@routstr/sdk";
 import { WalletConnect } from "applesauce-wallet-connect";
 import { RelayPool } from "applesauce-relay";
 import { logger } from "../../utils/logger";
@@ -16,6 +15,100 @@ export function decodeCashuTokenAmount(token: string): {
     decoded?.proofs?.reduce((sum, proof) => sum + proof.amount.toNumber(), 0) ?? 0;
   const unit = decoded?.unit === "msat" ? "msat" : "sat";
   return { amount, unit };
+}
+
+type SendCashuOptions = {
+  maxRetries?: number;
+  retryDelayMs?: number;
+  minimumAmountSats?: number;
+  fallbackAmounts?: number[];
+};
+
+const MIN_PROVIDER_TOKEN_AMOUNT_SATS = 2;
+
+export function getSameMintSendAmounts(
+  amount: number,
+  availableBalance: number,
+): number[] {
+  const requestedAmount = Math.max(
+    Math.ceil(amount),
+    MIN_PROVIDER_TOKEN_AMOUNT_SATS,
+  );
+  const available = Math.floor(availableBalance);
+  const candidates = [requestedAmount];
+
+  if (available <= requestedAmount) return candidates;
+
+  let denomination = 2 ** Math.ceil(Math.log2(requestedAmount));
+  while (denomination <= available) {
+    if (!candidates.includes(denomination)) candidates.push(denomination);
+    denomination *= 2;
+  }
+
+  // The entire ready balance is always worth trying last: even when no single
+  // power-of-two proof exists, all ready proofs together may be selectable.
+  if (!candidates.includes(available)) candidates.push(available);
+  return candidates;
+}
+
+/**
+ * Create a token from exactly the requested mint.
+ *
+ * The SDK associates the returned token with `mintUrl`. Falling back to another
+ * mint here makes that association false and can send providers a token from a
+ * mint they cannot reach. Cross-mint fallback belongs above this adapter, where
+ * the actual mint URL remains part of the request state.
+ */
+export async function sendCashuFromMint(
+  client: Pick<CocodClient, "sendCashu">,
+  mintUrl: string,
+  amount: number,
+  options: SendCashuOptions = {},
+): Promise<string> {
+  const maxRetries = options.maxRetries ?? 3;
+  const retryDelayMs = options.retryDelayMs ?? 5000;
+  const minimumAmountSats = options.minimumAmountSats ?? MIN_PROVIDER_TOKEN_AMOUNT_SATS;
+  const sendAmounts = [
+    Math.max(amount, minimumAmountSats),
+    ...(options.fallbackAmounts ?? []),
+  ].filter((candidate, index, all) => candidate > 0 && all.indexOf(candidate) === index);
+  const retryErrorPattern = "Proof already reserved by operation";
+  let lastInsufficientProofsError: unknown;
+
+  for (const [amountIndex, sendAmount] of sendAmounts.entries()) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await client.sendCashu(sendAmount, mintUrl);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const shouldRetry =
+          attempt < maxRetries && errorMessage.includes(retryErrorPattern);
+
+        if (shouldRetry) {
+          logger.log(
+            `sendToken attempt ${attempt + 1} failed with reserved proof error for ${mintUrl}, retrying in ${retryDelayMs / 1000}s...`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+          continue;
+        }
+
+        if (
+          errorMessage.includes("Not enough proofs") &&
+          amountIndex + 1 < sendAmounts.length
+        ) {
+          lastInsufficientProofsError = error;
+          logger.warn(
+            `sendToken: ${mintUrl} cannot compose ${sendAmount} sats; trying ${sendAmounts[amountIndex + 1]} sats from the same mint`,
+          );
+          break;
+        }
+
+        throw error;
+      }
+    }
+  }
+
+  throw lastInsufficientProofsError ?? new Error("sendToken failed after max retries");
 }
 
 export interface WalletAdapterOptions {
@@ -268,38 +361,21 @@ export async function createWalletAdapter(
       return options.getAutoRefillConfig?.() ?? options.autoRefill;
     },
     async sendToken(mintUrl: string, amount: number): Promise<string> {
-      const maxRetries = 3;
-      const retryDelayMs = 5000;
-      const retryErrorPattern = "Proof already reserved by operation";
-
-      for (let attempt = 0; attempt <= maxRetries; attempt++) {
-        try {
-          return await client.sendCashu(amount, mintUrl);
-        } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-
-          const shouldRetry =
-            attempt < maxRetries && errorMessage.includes(retryErrorPattern);
-
-          if (shouldRetry) {
-            logger.log(
-              `sendToken attempt ${attempt + 1} failed with reserved proof error, retrying in ${retryDelayMs / 1000}s...`,
-            );
-            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-            continue;
-          }
-
-          if (errorMessage.includes("Not enough proofs")) {
-            throw new InsufficientBalanceError(amount, 0);
-          }
-
-          logger.error("Error in walletAdapter sendToken:", error);
-          throw error;
-        }
+      try {
+        const balances: Record<string, number> = await syncMintState().catch(
+          () => ({}),
+        );
+        const sendAmounts = getSameMintSendAmounts(
+          amount,
+          balances[mintUrl] ?? amount,
+        );
+        return await sendCashuFromMint(client, mintUrl, sendAmounts[0]!, {
+          fallbackAmounts: sendAmounts.slice(1),
+        });
+      } catch (error) {
+        logger.error("Error in walletAdapter sendToken:", error);
+        throw error;
       }
-
-      throw new Error("sendToken failed after max retries");
     },
     async receiveToken(token: string): Promise<{
       success: boolean;

--- a/src/daemon/wallet/mint-fallback.ts
+++ b/src/daemon/wallet/mint-fallback.ts
@@ -1,0 +1,89 @@
+import type { CocodClient } from "./cocod-client";
+import { logger } from "../../utils/logger";
+
+export interface Bolt11InvoiceResult {
+  invoice: string;
+  mintUrl: string;
+}
+
+function uniqueMintUrls(mints: Array<string | undefined | null>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const mint of mints) {
+    const trimmed = mint?.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function inspectForMintUnreachable(value: unknown): boolean {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (/mint[_-]unreachable/i.test(trimmed) || /mint\b.*\bunreachable/i.test(trimmed)) return true;
+
+    if ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+      try {
+        return inspectForMintUnreachable(JSON.parse(trimmed));
+      } catch {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  if (!value || typeof value !== "object") return false;
+
+  if (value instanceof Error) {
+    return inspectForMintUnreachable(value.message) ||
+      inspectForMintUnreachable((value as Error & { cause?: unknown }).cause);
+  }
+
+  return Object.values(value).some((entry) => inspectForMintUnreachable(entry));
+}
+
+export function isMintUnreachableError(error: unknown): boolean {
+  return inspectForMintUnreachable(error);
+}
+
+export async function receiveBolt11WithMintFallback(
+  cocod: CocodClient,
+  amount: number,
+  mintUrls: string[],
+  context: string,
+): Promise<Bolt11InvoiceResult> {
+  const candidates = uniqueMintUrls(mintUrls);
+  if (candidates.length === 0) {
+    throw new Error("No active mint configured");
+  }
+
+  let lastMintUnreachableError: unknown;
+  for (const [index, mintUrl] of candidates.entries()) {
+    try {
+      if (index > 0) {
+        logger.log(
+          `${context} Retrying top-up with fallback mint ${mintUrl} (${index + 1}/${candidates.length})...`,
+        );
+      }
+      const invoice = await cocod.receiveBolt11(amount, mintUrl);
+      return { invoice, mintUrl };
+    } catch (error) {
+      if (!isMintUnreachableError(error)) {
+        throw error;
+      }
+
+      lastMintUnreachableError = error;
+      logger.warn(
+        `${context} Mint unreachable while creating top-up invoice via ${mintUrl}.` +
+          (index + 1 < candidates.length ? " Trying next configured mint." : " No fallback mints left."),
+      );
+    }
+  }
+
+  throw lastMintUnreachableError instanceof Error
+    ? lastMintUnreachableError
+    : new Error("All configured mints are unreachable");
+}

--- a/src/daemon/wallet/sdk-mint-fallback.ts
+++ b/src/daemon/wallet/sdk-mint-fallback.ts
@@ -33,6 +33,7 @@ type WalletAdapterLike = {
 };
 
 const PATCH_MARKER = Symbol.for("routstrd.mintFallbackTopUpPatched");
+const ERROR_RETRY_PATCH_MARKER = Symbol.for("routstrd.mintFallbackErrorRetryPatched");
 
 function uniqueMintUrls(mints: Array<string | undefined | null>): string[] {
   const seen = new Set<string>();
@@ -49,6 +50,10 @@ function uniqueMintUrls(mints: Array<string | undefined | null>): string[] {
 function isMintUnreachableTopUpResult(result: TopUpResult): boolean {
   return !result.success &&
     (isMintUnreachableError(result.message) || isMintUnreachableError(result.error));
+}
+
+function isMintUnreachableResponse(status: number, responseBody: unknown): boolean {
+  return status >= 500 && isMintUnreachableError(responseBody);
 }
 
 async function getTopUpMintCandidates(
@@ -74,6 +79,8 @@ export function installMintFallbackTopUp(
   walletAdapter: WalletAdapterLike,
   logger: LoggerLike,
 ): void {
+  installMintUnreachableErrorRetry(client, walletClient, walletAdapter, logger);
+
   const balanceManager = client.getBalanceManager() as BalanceManagerLike & {
     [PATCH_MARKER]?: boolean;
   };
@@ -111,4 +118,112 @@ export function installMintFallbackTopUp(
   };
 
   balanceManager[PATCH_MARKER] = true;
+}
+
+export function installMintUnreachableErrorRetry(
+  client: RoutstrClientLike,
+  walletClient: CocodClient,
+  walletAdapter: WalletAdapterLike,
+  logger: LoggerLike,
+): void {
+  const patchedClient = client as RoutstrClientLike & Record<string, any> & { [ERROR_RETRY_PATCH_MARKER]?: boolean };
+  if (patchedClient[ERROR_RETRY_PATCH_MARKER]) return;
+
+  const originalHandleErrorResponse = patchedClient._handleErrorResponse;
+  if (typeof originalHandleErrorResponse !== "function") return;
+
+  patchedClient._handleErrorResponse = async function patchedHandleErrorResponse(
+    this: Record<string, any>,
+    params: Record<string, any>,
+    token: string,
+    status: number,
+    requestId: string | undefined,
+    xCashuRefundToken: string | undefined,
+    responseBody: unknown,
+    retryCount = 0,
+  ): Promise<unknown> {
+    const mode = this.mode;
+    const baseUrl = params?.baseUrl;
+    const initialMintUrl = params?.mintUrl;
+
+    if (
+      mode === "apikeys" &&
+      baseUrl &&
+      !params?.mintFallbackAttempted &&
+      isMintUnreachableResponse(status, responseBody)
+    ) {
+      const candidates = (await getTopUpMintCandidates(
+        initialMintUrl,
+        walletClient,
+        walletAdapter,
+      )).filter((mintUrl) => mintUrl !== initialMintUrl);
+
+      if (candidates.length > 0) {
+        logger.warn(
+          `[wallet] Provider ${baseUrl} rejected the stored API key because its source mint is unreachable. ` +
+            `Trying ${candidates.length} fallback mint(s) before provider failover.`,
+        );
+      }
+
+      for (const [index, mintUrl] of candidates.entries()) {
+        try {
+          this.storageAdapter?.removeApiKey?.(baseUrl);
+          logger.log(
+            `[wallet] Retrying ${baseUrl} with a fresh API key from fallback mint ${mintUrl} ` +
+              `(${index + 1}/${candidates.length})...`,
+          );
+
+          const spendResult = await this._spendToken({
+            mintUrl,
+            amount: params.requiredSats,
+            baseUrl,
+          });
+
+          const retryToken = spendResult.token;
+          if (!retryToken) {
+            throw new Error("Fresh API key creation returned no token");
+          }
+
+          const retryResponse = await this._makeRequest({
+            ...params,
+            mintUrl,
+            token: retryToken,
+            requiredSats: params.requiredSats,
+            headers: this._withAuthAndTinfoilHeaders(
+              params.baseHeaders,
+              retryToken,
+              params.tinfoilEnabled,
+              params.selectedModel?.id,
+            ),
+            retryCount: retryCount + 1,
+            mintFallbackAttempted: true,
+          });
+
+          retryResponse.initialTokenBalanceInSats = spendResult.tokenBalanceUnit === "msat"
+            ? spendResult.tokenBalance / 1_000
+            : spendResult.tokenBalance;
+          retryResponse.initialTokenBalanceUnknown = spendResult.tokenBalanceUnknown;
+          return retryResponse;
+        } catch (error) {
+          logger.warn(
+            `[wallet] Fallback mint ${mintUrl} could not create a replacement API key for ${baseUrl}: ` +
+              (error instanceof Error ? error.message : String(error)),
+          );
+        }
+      }
+    }
+
+    return originalHandleErrorResponse.call(
+      this,
+      params,
+      token,
+      status,
+      requestId,
+      xCashuRefundToken,
+      responseBody,
+      retryCount,
+    );
+  };
+
+  patchedClient[ERROR_RETRY_PATCH_MARKER] = true;
 }

--- a/src/daemon/wallet/sdk-mint-fallback.ts
+++ b/src/daemon/wallet/sdk-mint-fallback.ts
@@ -1,0 +1,114 @@
+import type { CocodClient } from "./cocod-client";
+import { isMintUnreachableError } from "./mint-fallback";
+
+type LoggerLike = {
+  log: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+};
+
+type TopUpOptions = {
+  mintUrl: string;
+  baseUrl: string;
+  amount: number;
+  token?: string;
+};
+
+type TopUpResult = {
+  success: boolean;
+  message?: unknown;
+  error?: unknown;
+  [key: string]: unknown;
+};
+
+type BalanceManagerLike = {
+  topUp(options: TopUpOptions): Promise<TopUpResult>;
+};
+
+type RoutstrClientLike = {
+  getBalanceManager(): unknown;
+};
+
+type WalletAdapterLike = {
+  getBalances(): Promise<Record<string, number>>;
+};
+
+const PATCH_MARKER = Symbol.for("routstrd.mintFallbackTopUpPatched");
+
+function uniqueMintUrls(mints: Array<string | undefined | null>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const mint of mints) {
+    const trimmed = mint?.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function isMintUnreachableTopUpResult(result: TopUpResult): boolean {
+  return !result.success &&
+    (isMintUnreachableError(result.message) || isMintUnreachableError(result.error));
+}
+
+async function getTopUpMintCandidates(
+  initialMintUrl: string,
+  walletClient: CocodClient,
+  walletAdapter: WalletAdapterLike,
+): Promise<string[]> {
+  const [configuredMints, balances] = await Promise.all([
+    walletClient.listMints().catch(() => []),
+    walletAdapter.getBalances().catch(() => ({})),
+  ]);
+
+  return uniqueMintUrls([
+    initialMintUrl,
+    ...configuredMints,
+    ...Object.keys(balances),
+  ]);
+}
+
+export function installMintFallbackTopUp(
+  client: RoutstrClientLike,
+  walletClient: CocodClient,
+  walletAdapter: WalletAdapterLike,
+  logger: LoggerLike,
+): void {
+  const balanceManager = client.getBalanceManager() as BalanceManagerLike & {
+    [PATCH_MARKER]?: boolean;
+  };
+  if (balanceManager[PATCH_MARKER]) return;
+
+  const originalTopUp = balanceManager.topUp.bind(balanceManager);
+  balanceManager.topUp = async (options: TopUpOptions): Promise<TopUpResult> => {
+    const candidates = await getTopUpMintCandidates(
+      options.mintUrl,
+      walletClient,
+      walletAdapter,
+    );
+
+    let lastMintUnreachableResult: TopUpResult | undefined;
+    for (const [index, mintUrl] of candidates.entries()) {
+      if (index > 0) {
+        logger.log(
+          `[wallet] Retrying provider top-up with fallback mint ${mintUrl} (${index + 1}/${candidates.length})...`,
+        );
+      }
+
+      const result = await originalTopUp({ ...options, mintUrl });
+      if (!isMintUnreachableTopUpResult(result)) {
+        return result;
+      }
+
+      lastMintUnreachableResult = result;
+      logger.warn(
+        `[wallet] Provider top-up mint unreachable for ${mintUrl}.` +
+          (index + 1 < candidates.length ? " Trying next configured mint." : " No fallback mints left."),
+      );
+    }
+
+    return lastMintUnreachableResult ?? originalTopUp(options);
+  };
+
+  balanceManager[PATCH_MARKER] = true;
+}

--- a/src/daemon/wallet/sdk-mint-fallback.ts
+++ b/src/daemon/wallet/sdk-mint-fallback.ts
@@ -177,6 +177,7 @@ export function installMintUnreachableErrorRetry(
             mintUrl,
             amount: params.requiredSats,
             baseUrl,
+            excludeMints: [initialMintUrl],
           });
 
           const retryToken = spendResult.token;

--- a/tests/mint-fallback.test.ts
+++ b/tests/mint-fallback.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { CocodClient } from "../src/daemon/wallet/cocod-client";
+import {
+  isMintUnreachableError,
+  receiveBolt11WithMintFallback,
+} from "../src/daemon/wallet/mint-fallback";
+
+function createClient(receiveBolt11: CocodClient["receiveBolt11"]): CocodClient {
+  return {
+    ping: async () => true,
+    getStatus: async () => "UNLOCKED",
+    unlock: async () => "ok",
+    getBalances: async () => ({}),
+    receiveCashu: async () => "ok",
+    receiveBolt11,
+    sendCashu: async () => "token",
+    sendBolt11: async () => "ok",
+    listMints: async () => [],
+    addMint: async () => "ok",
+    getMintInfo: async () => ({}),
+  };
+}
+
+describe("mint fallback", () => {
+  test("detects mint_unreachable in nested error payloads", () => {
+    expect(isMintUnreachableError(new Error("mint_unreachable"))).toBe(true);
+    expect(
+      isMintUnreachableError(
+        new Error(
+          "The mint that issued this Cashu token is unreachable; the token cannot be redeemed at another mint",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isMintUnreachableError(
+        JSON.stringify({ detail: { error: { type: "mint_unreachable" } } }),
+      ),
+    ).toBe(true);
+    expect(isMintUnreachableError(new Error("invoice expired"))).toBe(false);
+  });
+
+  test("tries the next configured mint only for mint_unreachable", async () => {
+    const attempts: string[] = [];
+    const client = createClient(async (_amount, mintUrl) => {
+      attempts.push(mintUrl || "");
+      if (mintUrl === "https://mint-a.example") {
+        throw new Error(
+          JSON.stringify({ detail: { error: { type: "mint_unreachable" } } }),
+        );
+      }
+      return "lnbc1fallback";
+    });
+
+    const result = await receiveBolt11WithMintFallback(
+      client,
+      21,
+      ["https://mint-a.example", "https://mint-b.example"],
+      "[test]",
+    );
+
+    expect(result).toEqual({
+      invoice: "lnbc1fallback",
+      mintUrl: "https://mint-b.example",
+    });
+    expect(attempts).toEqual(["https://mint-a.example", "https://mint-b.example"]);
+  });
+
+  test("does not fallback for non-mint-unreachable errors", async () => {
+    const attempts: string[] = [];
+    const client = createClient(async (_amount, mintUrl) => {
+      attempts.push(mintUrl || "");
+      throw new Error("insufficient balance");
+    });
+
+    await expect(
+      receiveBolt11WithMintFallback(
+        client,
+        21,
+        ["https://mint-a.example", "https://mint-b.example"],
+        "[test]",
+      ),
+    ).rejects.toThrow("insufficient balance");
+    expect(attempts).toEqual(["https://mint-a.example"]);
+  });
+});

--- a/tests/mint-fallback.test.ts
+++ b/tests/mint-fallback.test.ts
@@ -4,6 +4,10 @@ import {
   isMintUnreachableError,
   receiveBolt11WithMintFallback,
 } from "../src/daemon/wallet/mint-fallback";
+import {
+  getSameMintSendAmounts,
+  sendCashuFromMint,
+} from "../src/daemon/wallet";
 
 function createClient(receiveBolt11: CocodClient["receiveBolt11"]): CocodClient {
   return {
@@ -20,6 +24,88 @@ function createClient(receiveBolt11: CocodClient["receiveBolt11"]): CocodClient 
     getMintInfo: async () => ({}),
   };
 }
+
+describe("wallet token mint identity", () => {
+  test("builds bounded same-mint denomination fallbacks", () => {
+    expect(getSameMintSendAmounts(17, 4103)).toEqual([
+      17,
+      32,
+      64,
+      128,
+      256,
+      512,
+      1024,
+      2048,
+      4096,
+      4103,
+    ]);
+    expect(getSameMintSendAmounts(1, 1)).toEqual([2]);
+  });
+
+  test("creates at least two sats so proof fees cannot consume the whole token", async () => {
+    const amounts: number[] = [];
+    const client = {
+      sendCashu: async (amount: number) => {
+        amounts.push(amount);
+        return "two-sat-token";
+      },
+    };
+
+    await expect(
+      sendCashuFromMint(client, "https://mint-a.example", 1, {
+        maxRetries: 0,
+        retryDelayMs: 0,
+      }),
+    ).resolves.toBe("two-sat-token");
+
+    expect(amounts).toEqual([2]);
+  });
+
+  test("never silently creates a token from a different mint", async () => {
+    const attempts: string[] = [];
+    const client = {
+      sendCashu: async (_amount: number, mintUrl?: string) => {
+        attempts.push(mintUrl || "");
+        throw new Error("Not enough proofs to send");
+      },
+    };
+
+    await expect(
+      sendCashuFromMint(client, "https://mint-a.example", 21, {
+        maxRetries: 0,
+        retryDelayMs: 0,
+      }),
+    ).rejects.toThrow("Not enough proofs");
+
+    expect(attempts).toEqual(["https://mint-a.example"]);
+  });
+
+  test("retries only the same mint for temporarily reserved proofs", async () => {
+    const attempts: string[] = [];
+    const client = {
+      sendCashu: async (_amount: number, mintUrl?: string) => {
+        attempts.push(mintUrl || "");
+        if (attempts.length === 1) {
+          throw new Error("Proof already reserved by operation");
+        }
+        return "token-from-mint-a";
+      },
+    };
+
+    const token = await sendCashuFromMint(
+      client,
+      "https://mint-a.example",
+      21,
+      { maxRetries: 1, retryDelayMs: 0 },
+    );
+
+    expect(token).toBe("token-from-mint-a");
+    expect(attempts).toEqual([
+      "https://mint-a.example",
+      "https://mint-a.example",
+    ]);
+  });
+});
 
 describe("mint fallback", () => {
   test("detects mint_unreachable in nested error payloads", () => {

--- a/tests/sdk-mint-fallback.test.ts
+++ b/tests/sdk-mint-fallback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { CocodClient } from "../src/daemon/wallet/cocod-client";
+import { installMintFallbackTopUp } from "../src/daemon/wallet/sdk-mint-fallback";
+
+function createCocodClient(mints: string[]): CocodClient {
+  return {
+    ping: async () => true,
+    getStatus: async () => "UNLOCKED",
+    unlock: async () => "ok",
+    getBalances: async () => ({}),
+    receiveCashu: async () => "ok",
+    receiveBolt11: async () => "invoice",
+    sendCashu: async () => "token",
+    sendBolt11: async () => "ok",
+    listMints: async () => mints,
+    addMint: async () => "ok",
+    getMintInfo: async () => ({}),
+  };
+}
+
+describe("SDK top-up mint fallback", () => {
+  test("retries provider top-up on mint_unreachable result", async () => {
+    const attempts: string[] = [];
+    const balanceManager = {
+      topUp: async (options: { mintUrl: string }) => {
+        attempts.push(options.mintUrl);
+        if (options.mintUrl === "https://mint-a.example") {
+          return {
+            success: false,
+            message: { detail: { error: { type: "mint_unreachable" } } },
+          };
+        }
+        return { success: true, toppedUpAmount: 21 };
+      },
+    };
+    const client = { getBalanceManager: () => balanceManager };
+    const walletAdapter = {
+      getBalances: async () => ({ "https://mint-c.example": 100 }),
+    };
+
+    installMintFallbackTopUp(
+      client,
+      createCocodClient(["https://mint-a.example", "https://mint-b.example"]),
+      walletAdapter,
+      { log: () => undefined, warn: () => undefined },
+    );
+
+    const result = await balanceManager.topUp({
+      mintUrl: "https://mint-a.example",
+      baseUrl: "https://provider.example",
+      amount: 21,
+      token: "sk-test",
+    });
+
+    expect(result.success).toBe(true);
+    expect(attempts).toEqual(["https://mint-a.example", "https://mint-b.example"]);
+  });
+
+  test("does not retry provider top-up on unrelated failure", async () => {
+    const attempts: string[] = [];
+    const balanceManager = {
+      topUp: async (options: { mintUrl: string }) => {
+        attempts.push(options.mintUrl);
+        return { success: false, message: "insufficient balance" };
+      },
+    };
+    const client = { getBalanceManager: () => balanceManager };
+    const walletAdapter = { getBalances: async () => ({}) };
+
+    installMintFallbackTopUp(
+      client,
+      createCocodClient(["https://mint-a.example", "https://mint-b.example"]),
+      walletAdapter,
+      { log: () => undefined, warn: () => undefined },
+    );
+
+    const result = await balanceManager.topUp({
+      mintUrl: "https://mint-a.example",
+      baseUrl: "https://provider.example",
+      amount: 21,
+    });
+
+    expect(result).toEqual({ success: false, message: "insufficient balance" });
+    expect(attempts).toEqual(["https://mint-a.example"]);
+  });
+});

--- a/tests/sdk-mint-fallback.test.ts
+++ b/tests/sdk-mint-fallback.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { CocodClient } from "../src/daemon/wallet/cocod-client";
-import { installMintFallbackTopUp } from "../src/daemon/wallet/sdk-mint-fallback";
+import {
+  installMintFallbackTopUp,
+  installMintUnreachableErrorRetry,
+} from "../src/daemon/wallet/sdk-mint-fallback";
 
 function createCocodClient(mints: string[]): CocodClient {
   return {
@@ -54,6 +57,78 @@ describe("SDK top-up mint fallback", () => {
 
     expect(result.success).toBe(true);
     expect(attempts).toEqual(["https://mint-a.example", "https://mint-b.example"]);
+  });
+
+  test("replaces an API key from a fallback mint before provider failover on mint_unreachable", async () => {
+    const removedApiKeys: string[] = [];
+    const spendAttempts: string[] = [];
+    const retryRequests: Array<{ baseUrl: string; mintUrl: string; token: string; mintFallbackAttempted?: boolean }> = [];
+    const client = {
+      mode: "apikeys",
+      getBalanceManager: () => ({ topUp: async () => ({ success: true }) }),
+      storageAdapter: {
+        removeApiKey: (baseUrl: string) => removedApiKeys.push(baseUrl),
+      },
+      _spendToken: async (options: { mintUrl: string; baseUrl: string }) => {
+        spendAttempts.push(options.mintUrl);
+        return {
+          token: `token-from-${options.mintUrl}`,
+          tokenBalance: 42,
+          tokenBalanceUnit: "sat",
+          tokenBalanceUnknown: false,
+        };
+      },
+      _withAuthAndTinfoilHeaders: (_headers: unknown, token: string) => ({ authorization: token }),
+      _makeRequest: async (options: { baseUrl: string; mintUrl: string; token: string }) => {
+        retryRequests.push(options);
+        return { ok: true };
+      },
+      _handleErrorResponse: async () => {
+        throw new Error("provider failover should not run");
+      },
+    };
+    const walletAdapter = {
+      getBalances: async () => ({ "https://mint-b.example": 100 }),
+    };
+
+    installMintUnreachableErrorRetry(
+      client,
+      createCocodClient(["https://mint-a.example", "https://mint-b.example"]),
+      walletAdapter,
+      { log: () => undefined, warn: () => undefined },
+    );
+
+    const result = await client._handleErrorResponse(
+      {
+        baseUrl: "https://provider.example",
+        mintUrl: "https://mint-a.example",
+        requiredSats: 21,
+        baseHeaders: {},
+        tinfoilEnabled: false,
+        selectedModel: { id: "glm-5.2" },
+      },
+      "old-token",
+      503,
+      "request-id",
+      undefined,
+      JSON.stringify({ detail: { error: { type: "mint_unreachable" } } }),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      initialTokenBalanceInSats: 42,
+      initialTokenBalanceUnknown: false,
+    });
+    expect(removedApiKeys).toEqual(["https://provider.example"]);
+    expect(spendAttempts).toEqual(["https://mint-b.example"]);
+    expect(retryRequests).toMatchObject([
+      {
+        baseUrl: "https://provider.example",
+        mintUrl: "https://mint-b.example",
+        token: "token-from-https://mint-b.example",
+        mintFallbackAttempted: true,
+      },
+    ]);
   });
 
   test("does not retry provider top-up on unrelated failure", async () => {

--- a/tests/wallet-send-fallback.test.ts
+++ b/tests/wallet-send-fallback.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { createWalletAdapter } from "../src/daemon/wallet";
+import type { CocodClient } from "../src/daemon/wallet/cocod-client";
+
+function createClient(overrides: Partial<CocodClient>): CocodClient {
+  return {
+    ping: async () => true,
+    getStatus: async () => "UNLOCKED",
+    unlock: async () => "ok",
+    getBalances: async () => ({}),
+    receiveCashu: async () => "ok",
+    receiveBolt11: async () => "invoice",
+    sendCashu: async () => "token",
+    sendBolt11: async () => "ok",
+    listMints: async () => [],
+    addMint: async () => "ok",
+    getMintInfo: async () => ({}),
+    ...overrides,
+  };
+}
+
+describe("wallet sendToken mint identity", () => {
+  test("uses a larger denomination from the same mint when the exact amount cannot be composed", async () => {
+    const attempts: Array<{ amount: number; mintUrl: string }> = [];
+    const client = createClient({
+      getBalances: async () => ({
+        "https://mint.cubabitcoin.org": 4104,
+        "https://mint.minibits.cash/Bitcoin": 61409,
+      }),
+      listMints: async () => [
+        "https://mint.minibits.cash/Bitcoin",
+        "https://mint.cubabitcoin.org",
+      ],
+      sendCashu: async (amount, mintUrl) => {
+        attempts.push({ amount, mintUrl: mintUrl || "" });
+        if (amount === 1024) return "cashu-larger-same-mint-token";
+        throw new Error("Not enough proofs");
+      },
+    });
+
+    const walletAdapter = await createWalletAdapter({ walletClient: client });
+
+    await expect(
+      walletAdapter.sendToken("https://mint.cubabitcoin.org", 612),
+    ).resolves.toBe("cashu-larger-same-mint-token");
+    expect(attempts).toEqual([
+      { amount: 612, mintUrl: "https://mint.cubabitcoin.org" },
+      { amount: 1024, mintUrl: "https://mint.cubabitcoin.org" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

When a provider rejects a Cashu token with `mint_unreachable` (e.g. `routstr.otrta.me` can't reach `mint.minibits.cash`), the mint fallback handler in `sdk-mint-fallback.ts` calls `_spendToken` with a fallback mint URL (e.g. `mint.cubabitcoin.org`).

However, `_spendToken` → `createProviderToken` → `_selectCandidateMints` puts the **highest-balance mint first** regardless of the `preferredMintUrl` parameter. So the fallback token was still minted from the same unreachable mint:

```
_spendToken: mintUrl=https://mint.cubabitcoin.org  ← requested
createProviderToken: attempting mint=https://mint.minibits.cash/Bitcoin  ← actually used
→ 503 mint_unreachable again
```

## Fix

Pass `excludeMints: [initialMintUrl]` to `_spendToken` so the failed mint is excluded from candidate selection, forcing the fallback to actually use the requested alternative mint.

## Verification

Tested with `deepseek-v4-pro` through local routstrd → `routstr.otrta.me`:

```
[wallet] Retrying routstr.otrta.me with fallback mint mint.cubabitcoin.org (1/1)...
createProviderToken: attempting mint=https://mint.cubabitcoin.org amount=1
createProviderToken: success from mint=https://mint.cubabitcoin.org  ✓
LATEST Balance 970 sk-553...7e82 routstr.otrta.me/  ✓
```

No provider failover — requests stay on `routstr.otrta.me` as intended.