### PR TITLE
fix: integration configs no longer land in the working directory on Windows

### DIFF
--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -6,6 +6,8 @@ import { installOpenClawIntegration } from "./openclaw";
 import { installClaudeCodeIntegration } from "./claudecode";
 import { installHermesIntegration } from "./hermes";
 
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+
 export interface IntegrationConfig {
   clientId: string;
   name: string;
@@ -28,27 +30,27 @@ export const CLIENT_CONFIGS: Record<string, IntegrationConfig> = {
   opencode: {
     clientId: "opencode",
     name: "OpenCode",
-    configPath: join(process.env.HOME || "", ".config/opencode/opencode.json"),
+    configPath: join(HOME, ".config/opencode/opencode.json"),
   },
   "pi-agent": {
     clientId: "pi-agent",
     name: "Pi Agent",
-    configPath: join(process.env.HOME || "", ".pi/agent/models.json"),
+    configPath: join(HOME, ".pi/agent/models.json"),
   },
   openclaw: {
     clientId: "openclaw",
     name: "OpenClaw",
-    configPath: join(process.env.HOME || "", ".openclaw/openclaw.json"),
+    configPath: join(HOME, ".openclaw/openclaw.json"),
   },
   "claude-code": {
     clientId: "claude-code",
     name: "Claude Code",
-    configPath: join(process.env.HOME || "", ".claude/settings.json"),
+    configPath: join(HOME, ".claude/settings.json"),
   },
   hermes: {
     clientId: "hermes",
     name: "Hermes",
-    configPath: join(process.env.HOME || "", ".hermes/config.yaml"),
+    configPath: join(HOME, ".hermes/config.yaml"),
   },
 };
 


### PR DESCRIPTION
Found this while testing PR #44 on Windows.

`registry.ts` builds the integration paths from `process.env.HOME`. Windows doesn't set HOME, it uses USERPROFILE, so the path comes out as just `.claude\settings.json` with no drive letter. That means the current folder, so the config gets written wherever you happened to run the command from:

`Successfully updated .claude\settings.json with routstr settings.`

The agent never picks it up, and the file with the API key is left sitting in that folder. The daemon does the same thing at startup and every 21 minutes. All five integrations, not just Claude Code.

`config.ts`, `logger.ts` and `cocod-client.ts` already fall back to USERPROFILE, this file just missed it.

Tested on Windows 11 with PowerShell. Before, starting the daemon in an empty folder dropped a `.claude/settings.json` there. After, it goes to the home directory. No change on Linux or macOS since HOME is always set.

We could also swap all four of these to `os.homedir()` and drop the env juggling entirely. Happy to do that separately.