### PR TITLE
fix: leave the agent config alone when it cannot be loaded

### DIFF
--- a/src/integrations/claudecode.ts
+++ b/src/integrations/claudecode.ts
@@ -27,7 +27,8 @@ export async function installClaudeCodeIntegration(
       settings = JSON.parse(content);
     }
   } catch (error) {
-    console.error(`Error reading ${configPath}, creating new one.`);
+    console.error(`Failed to read or parse ${configPath}; leaving it unchanged:`, error);
+    return;
   }
 
   if (!settings.env) {

--- a/src/integrations/hermes.ts
+++ b/src/integrations/hermes.ts
@@ -99,7 +99,8 @@ export async function installHermesIntegration(
       content = await readFile(configPath, "utf-8");
     }
   } catch (error) {
-    console.error(`Error reading ${configPath}, creating new one.`);
+    console.error(`Failed to read ${configPath}; leaving it unchanged:`, error);
+    return;
   }
 
   let newContent: string;

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -67,8 +67,9 @@ export async function installOpenClawIntegration(
       const content = await readFile(configPath, "utf-8");
       openclawConfig = JSON.parse(content) as OpenClawConfig;
     }
-  } catch {
-    openclawConfig = {};
+  } catch (error) {
+    console.error(`Failed to read or parse ${configPath}; leaving it unchanged:`, error);
+    return;
   }
 
   if (!openclawConfig.models) {

--- a/src/integrations/opencode.ts
+++ b/src/integrations/opencode.ts
@@ -40,8 +40,9 @@ export async function installOpencodeIntegration(
     } else {
       opencodeConfig = { provider: {} };
     }
-  } catch {
-    opencodeConfig = { provider: {} };
+  } catch (error) {
+    console.error(`Failed to read or parse ${configPath}; leaving it unchanged:`, error);
+    return;
   }
 
   if (!opencodeConfig.provider) {

--- a/src/integrations/pi.ts
+++ b/src/integrations/pi.ts
@@ -40,8 +40,9 @@ export async function installPiIntegration(
       const content = await readFile(configPath, "utf-8");
       piConfig = JSON.parse(content) as PiConfig;
     }
-  } catch {
-    piConfig = {};
+  } catch (error) {
+    console.error(`Failed to read or parse ${configPath}; leaving it unchanged:`, error);
+    return;
   }
 
   if (!piConfig.providers) {


### PR DESCRIPTION
If routstrd can't read your existing agent config, it can end up replacing it instead of leaving it alone.

Here's an `opencode.json` with a comment in it, which opencode allows:

```jsonc
{
  // my defaults
  "model": "anthropic/claude-sonnet-4-5",
  "autoupdate": false
}
```

After the installer ran, all of it was gone and the file held only routstr's settings. It reported success while doing it.

The installers read the file inside a `try`. When that throws, the catch swallows it and carries on with an empty config, and that gets written over your file. It throws because we use strict `JSON.parse`, while opencode, openclaw and pi all allow comments or trailing commas in the files we read.

All five now return in that catch instead of carrying on, hermes included, which was only bailing on a bad parse and not on a failed read.

Checked : a config that fails to load is left byte-identical, a fresh install still creates the file, and a valid config still gets routstr's settings merged in.