### PR TITLE
feat: add 'routstrd local' command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -593,7 +593,7 @@ program
   .action(async () => {
     const config = await loadConfig();
 
-    if (!config.daemonUrl && !config.authUrl) {
+    if (!config.daemonUrl) {
       console.log("Already in local mode — no remote daemon URL is configured.");
       return;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -586,6 +586,39 @@ program
     }
   });
 
+// Local - switch back to local daemon mode (removes daemonUrl/authUrl)
+program
+  .command("local")
+  .description("Switch back to local daemon mode (removes remote daemon URL)")
+  .action(async () => {
+    const config = await loadConfig();
+
+    if (!config.daemonUrl && !config.authUrl) {
+      console.log("Already in local mode — no remote daemon URL is configured.");
+      return;
+    }
+
+    const previousDaemonUrl = config.daemonUrl;
+    const previousAuthUrl = config.authUrl;
+
+    const { daemonUrl: _daemonUrl, authUrl: _authUrl, ...rest } = config;
+    const updatedConfig: RoutstrdConfig = rest;
+
+    await Bun.write(CONFIG_FILE, JSON.stringify(updatedConfig, null, 2));
+
+    console.log("Switched back to local daemon mode.");
+    if (previousDaemonUrl) {
+      console.log(`  Removed remote daemon URL: ${previousDaemonUrl}`);
+    }
+    if (previousAuthUrl) {
+      console.log(`  Removed auth proxy URL: ${previousAuthUrl}`);
+    }
+    console.log(
+      `\nUse 'routstrd start' to start the local daemon.`,
+    );
+    console.log(`You can view the config file at: ${CONFIG_FILE}`);
+  });
+
 // Onboard - initialize the daemon
 program
   .command("onboard")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -614,7 +614,7 @@ program
       console.log(`  Removed auth proxy URL: ${previousAuthUrl}`);
     }
     console.log(
-      `\nUse 'routstrd start' to start the local daemon.`,
+      `\nUse 'routstrd onboard' for first time using local mode or 'routstrd start' to start the local daemon if you already are using it.`,
     );
     console.log(`You can view the config file at: ${CONFIG_FILE}`);
   });


### PR DESCRIPTION
## Summary

The `routstrd remote <url>` command sets `daemonUrl`/`authUrl` in the config to point at a remote daemon, but there was no CLI command to switch back to local mode — users had to manually edit `~/.routstrd/config.json` to remove those fields.

This PR adds `routstrd local` which:

- Removes `daemonUrl` and `authUrl` from the config file
- Preserves all other config (`nsec`, `port`, `host`, `mode`, etc.)
- Shows a clear message about what was removed
- Handles the already-local case gracefully ("Already in local mode")

## Usage

```bash
# Switch to remote
routstrd remote https://my-remote-node.com --auth-url https://auth-proxy.com

# Switch back to local
routstrd local
```

Output:
```
Switched back to local daemon mode.
  Removed remote daemon URL: https://my-remote-node.com
  Removed auth proxy URL: https://auth-proxy.com

Use 'routstrd start' to start the local daemon.
You can view the config file at: ~/.routstrd/config.json
```

## How it works

The daemon client checks `!!config.daemonUrl` to determine remote vs local mode. Removing the `daemonUrl` field makes all commands talk to the local daemon via the Unix socket again.