### PR TITLE
fix(wallet): normalize caller-supplied mint URLs

### DIFF
--- a/src/daemon/wallet/coco-client.ts
+++ b/src/daemon/wallet/coco-client.ts
@@ -701,7 +701,9 @@ export async function createCocoClient(
     },
 
     async receiveBolt11(amount: number, mintUrl?: string): Promise<string> {
-      const targetMint = mintUrl || walletConfig.defaultMintUrl;
+      const targetMint = mintUrl
+        ? normalizeMintUrl(mintUrl)
+        : walletConfig.defaultMintUrl;
       if (!targetMint) {
         throw new Error("No trusted mint available for Lightning invoice");
       }
@@ -717,7 +719,9 @@ export async function createCocoClient(
     },
 
     async sendCashu(amount: number, mintUrl?: string): Promise<string> {
-      const targetMint = mintUrl || walletConfig.defaultMintUrl;
+      const targetMint = mintUrl
+        ? normalizeMintUrl(mintUrl)
+        : walletConfig.defaultMintUrl;
       if (!targetMint) {
         throw new Error("No trusted mint available for sending");
       }
@@ -730,7 +734,9 @@ export async function createCocoClient(
     },
 
     async sendBolt11(invoice: string, mintUrl?: string): Promise<string> {
-      const targetMint = mintUrl || walletConfig.defaultMintUrl;
+      const targetMint = mintUrl
+        ? normalizeMintUrl(mintUrl)
+        : walletConfig.defaultMintUrl;
       if (!targetMint) {
         throw new Error("No trusted mint available for Lightning payment");
       }


### PR DESCRIPTION
Passing a mint URL with a trailing slash loses the payment. The invoice gets paid, the coins never arrive, and restarting doesn't recover them.

## Why

coco matches the mint URL as an exact string when it looks up the NUT-13 counter, so `https://mint.example/` gets a fresh row starting at 0 while the real one is already further along. The wallet then derives blinded messages the mint has already signed, and they get refused.

Nothing surfaces as a URL error, because cashu-ts normalizes the URL it actually calls. The request reaches the right mint; only the bookkeeping forks. Receive is where it costs you, since the invoice is paid before any of this. Send and melt fail safely, because proof selection finds nothing and throws before the counter is touched.

## What changed

`receiveBolt11`, `sendCashu` and `sendBolt11` now run the caller's `mintUrl` through `normalizeMintUrl` before handing it to coco. `addMint`, `getMintInfo` and `setDefaultMint` in the same file already did. `walletConfig.defaultMintUrl` is normalized at startup, so the no-argument path is unchanged.

## How tested

Against minibits with real sats: a 10 sat invoice created with a trailing slash, then paid from the same wallet.

```
main      balance 300 -> 290   counters .../Bitcoin 105 and .../Bitcoin/ 2   op pending
patched   balance 290 -> 290   counter  .../Bitcoin 108, no second row
```

Uppercase host, uppercase scheme, a double slash and `:443` fork it the same way. Build, tsc and the existing tests pass.

Those 10 sats stay stranded, since the operation is stored under the slashed URL, so this prevents new cases rather than recovering old ones. It doesn't touch the npubx.cash path, where the mint URL comes from the server rather than the caller.