### PR TITLE
fix(wallet): claim the auto-refill guard after the backoff check

### DIFF
--- a/src/daemon/wallet/auto-refill.ts
+++ b/src/daemon/wallet/auto-refill.ts
@@ -66,8 +66,6 @@ export function startAutoRefillLoop(
       return;
     }
 
-    checkInProgress = true;
-
     // If we've been failing too much, back off rather than retrying at full speed.
     // This prevents tight loops on transient errors.
     const backoffInterval = Math.min(
@@ -77,6 +75,8 @@ export function startAutoRefillLoop(
     if (now - lastAttemptAt < backoffInterval) {
       return;
     }
+
+    checkInProgress = true;
 
     try {
       const balances = await cocod.getBalances();


### PR DESCRIPTION
Auto-refill stops for good after its first transient failure. One timed-out payment and it never tries again until the daemon is restarted, silently.

## Why

`checkAndRefill` sets `checkInProgress = true`, then works out the backoff window and returns early if it's still inside it. That early return sits above the `try`, so the `finally` that clears the flag never runs. From then on every tick hits the `if (checkInProgress) return` guard at the top and gives up immediately.

It only takes one failure to get there. The catch sets `lastAttemptAt` and bumps `consecutiveFailures`, which pushes the backoff past the tick interval, so the very next tick takes that early return and leaks the flag.

Nothing errors and nothing logs, so the balance just quietly stops topping up.

## What changed

The flag is claimed after the backoff check rather than before it, so it's only set on the paths the `finally` can clear. Nothing between that assignment and the `try` yields, so two ticks still can't both get through the guard.

## How tested

Real wallet on minibits, real invoices created at the mint, with only the NWC payment stubbed to throw a transient error. Loop interval 1s, run for 20s.

```
main     1 invoice,  1 pay attempt   at 393ms, then nothing
patched  4 invoices, 4 pay attempts  at 341, 2289, 6283, 14295ms
```

Those gaps are the intended 2s, 4s and 8s backoff.