### PR TITLE
fix(wallet): fund the default mint on auto-refill

### DIFF
--- a/src/daemon/wallet/auto-refill.ts
+++ b/src/daemon/wallet/auto-refill.ts
@@ -94,11 +94,9 @@ export function startAutoRefillLoop(
         `[auto-refill] Balance ${totalBalance} sats < threshold ${config.threshold}. Refilling ${config.amount} sats...`,
       );
 
-      // Get active mint
-      const mints = await cocod.listMints();
-      const mintUrl = mints[0];
+      const mintUrl = await cocod.getDefaultMint();
       if (!mintUrl) {
-        logger.error("[auto-refill] No active mint configured");
+        logger.error("[auto-refill] No default mint configured");
         return;
       }
 


### PR DESCRIPTION
Auto-refill tops up a mint the wallet never spends from. The sats arrive, the total balance looks healthy, and sends still fail with "Not enough proofs to send".

## Why

`checkAndRefill` picks its mint with `listMints()[0]`. That query has no `ORDER BY`, so index 0 is just the oldest trusted row, and `setDefaultMint()` only writes `defaultMintUrl` to the config without touching that order. A new wallet trusts `mint.cubabitcoin.org` first, so it owns row 0 for good. Choose any other default and every refill lands on cubabitcoin, while sends, melts and the refund job all draw on the default.

It hides itself too. The threshold test sums balances across every mint, so once the wrong mint passes the threshold auto-refill goes quiet. Nothing errors and nothing logs.

`fundFromNWC` already does the same job correctly, with `await client.getDefaultMint()`.

## What changed

Auto-refill asks for the default mint. The `listMints()` call goes with it since nothing else used it, and the error string now names the condition it reports.

## How tested

Real wallet and mints, real invoice, real Lightning payment, with only the NWC funding wallet stood in for. Starting from 290 sats on minibits, default minibits, `listMints()[0]` cubabitcoin.

On main the invoice went to cubabitcoin, leaving 278 sats on minibits and 10 on cubabitcoin. Sending 279 then fails:

```
Not enough proofs to send
```

288 sats in the wallet and 279 of them unspendable. Patched, the invoice goes to minibits.

Already-stranded funds are not recovered; melt fees can exceed a small stranded amount. Independent of #76, which touches the same file elsewhere.